### PR TITLE
Revert change that accidentally got included

### DIFF
--- a/src/main/java/com/creativemd/littletiles/LittleTiles.java
+++ b/src/main/java/com/creativemd/littletiles/LittleTiles.java
@@ -64,7 +64,7 @@ public class LittleTiles {
     public static final String modid = "littletiles";
     public static final String version = LTTags.VERSION;
 
-    public static int maxNewTiles = 51200;
+    public static int maxNewTiles = 512;
 
     public static CreativeTabs creativeTabLittleTiles = new LittleTilesCreativeTab("littletiles");
 


### PR DESCRIPTION
This is a change that I often have for debugging, but it should not be part of the final product. It got accidentally included in one of my previous MRs, this undoes that.

It's the number how much the little hammer can split little tiles. It's that way for performance reasons, but for debugging you might want to increase it to see what happens.