### PR TITLE
Defend against blocks from removed mods

### DIFF
--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleToolHandler.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleToolHandler.java
@@ -41,7 +41,10 @@ public class LittleToolHandler {
     public Block getBlock() {
         NBTTagCompound tag = getTag(false);
         if (tag.hasKey("block")) {
-            return Block.getBlockById(tag.getInteger("block"));
+            Block ret = Block.getBlockById(tag.getInteger("block"));
+            if (ret != null && ret != Blocks.air) {
+                return ret;
+            }
         }
         return Blocks.stone;
     }


### PR DESCRIPTION
If we have a block from a now removed mod saved in our chisel `Block.getBlockById` will return `Blocks.air`. I added a null check just in case.