### PR TITLE
Fix placement bugs claude found

### DIFF
--- a/src/main/java/com/creativemd/littletiles/common/items/ItemBlockTiles.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemBlockTiles.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.block.Block;
-import net.minecraft.block.Block.SoundType;
 import net.minecraft.block.BlockAir;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -14,28 +13,20 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.creativemd.creativecore.common.packet.PacketHandler;
 import com.creativemd.creativecore.common.utils.CubeObject;
-import com.creativemd.creativecore.common.utils.HashMapList;
 import com.creativemd.creativecore.common.utils.WorldUtils;
 import com.creativemd.littletiles.LittleTiles;
 import com.creativemd.littletiles.client.render.ITilesRenderer;
 import com.creativemd.littletiles.client.render.PreviewRenderer;
-import com.creativemd.littletiles.client.util3d.Mesh3d;
-import com.creativemd.littletiles.client.util3d.Mesh3dUtil;
-import com.creativemd.littletiles.common.blocks.BlockTile;
 import com.creativemd.littletiles.common.blocks.ILittleTile;
 import com.creativemd.littletiles.common.packet.LittlePlacePacket;
 import com.creativemd.littletiles.common.structure.LittleStructure;
-import com.creativemd.littletiles.common.tileentity.TileEntityLittleTiles;
 import com.creativemd.littletiles.common.utils.LittleTile;
-import com.creativemd.littletiles.common.utils.LittleTile.LittleTilePosition;
 import com.creativemd.littletiles.common.utils.LittleTileBlock;
 import com.creativemd.littletiles.common.utils.LittleTileBlockPos;
 import com.creativemd.littletiles.common.utils.LittleTileCutoutInfo;
@@ -44,7 +35,6 @@ import com.creativemd.littletiles.common.utils.LittleTilePreview;
 import com.creativemd.littletiles.common.utils.LittleToolHandler;
 import com.creativemd.littletiles.common.utils.PlacementHelper;
 import com.creativemd.littletiles.common.utils.small.LittleTileBox;
-import com.creativemd.littletiles.common.utils.small.LittleTileCoord;
 import com.creativemd.littletiles.common.utils.small.LittleTileSize;
 import com.creativemd.littletiles.common.utils.small.LittleTileVec;
 import com.creativemd.littletiles.utils.PreviewTile;
@@ -184,133 +174,16 @@ public class ItemBlockTiles extends ItemBlock implements ILittleTile, ITilesRend
         return block.isReplaceable(world, x, y, z) || PlacementHelper.canBePlacedInsideBlock(player, x, y, z);
     }
 
-    public static HashMapList<ChunkCoordinates, PreviewTile> getSplittedTiles(ArrayList<PreviewTile> tiles, int x,
-            int y, int z) {
-        HashMapList<ChunkCoordinates, PreviewTile> splitted = new HashMapList<>();
-        for (PreviewTile tile : tiles) {
-            if (!tile.split(splitted, x, y, z)) return null;
-        }
-        return splitted;
-    }
-
-    public static boolean canPlaceTiles(World world, HashMapList<ChunkCoordinates, PreviewTile> splitted,
-            ArrayList<ChunkCoordinates> coordsToCheck) {
-        for (ChunkCoordinates coord : coordsToCheck) {
-            TileEntity mainTile = world.getTileEntity(coord.posX, coord.posY, coord.posZ);
-            if (mainTile instanceof TileEntityLittleTiles) {
-
-                ArrayList<PreviewTile> tiles = splitted.getValues(coord);
-                if (tiles != null) {
-                    for (PreviewTile tile : tiles) if (tile.needsCollisionTest()
-                            && !((TileEntityLittleTiles) mainTile).isSpaceForLittleTile(tile.box))
-                        return false;
-                }
-            } else if (!(world.getBlock(coord.posX, coord.posY, coord.posZ) instanceof BlockTile)
-                    && !world.getBlock(coord.posX, coord.posY, coord.posZ).getMaterial().isReplaceable())
-                return false;
-        }
-        return true;
-    }
-
     public static boolean placeTiles(World world, EntityPlayer player, ArrayList<PreviewTile> previews,
             LittleStructure structure, int x, int y, int z, ItemStack stack, ArrayList<LittleTile> unplaceableTiles,
             LittleTileCutoutInfo cutoutInfo, LittleTilePlaceMode placeMode) {
-
-        HashMapList<ChunkCoordinates, PreviewTile> splitted = getSplittedTiles(previews, x, y, z);
-        if (splitted == null) return false;
-
-        ArrayList<ChunkCoordinates> coordsToCheck = splitted.getKeys();
-        ArrayList<SoundType> soundsToBePlayed = new ArrayList<>();
-        boolean alwaysTryPlace = placeMode != LittleTilePlaceMode.NORMAL && structure == null;
-        if (alwaysTryPlace || canPlaceTiles(world, splitted, coordsToCheck)) {
-            LittleTilePosition pos = null;
-
-            boolean didPlace = false;
-
-            for (int i = 0; i < splitted.size(); i++) {
-                ChunkCoordinates coord = splitted.getKey(i);
-                ArrayList<PreviewTile> placeTiles = splitted.getValues(i);
-                boolean hascollideBlock = false;
-                for (PreviewTile tile : placeTiles) {
-                    if (tile.needsCollisionTest()) {
-                        hascollideBlock = true;
-                        break;
-                    }
-                }
-                if (hascollideBlock) {
-                    if (!(world.getBlock(coord.posX, coord.posY, coord.posZ) instanceof BlockTile)
-                            && world.getBlock(coord.posX, coord.posY, coord.posZ).getMaterial().isReplaceable())
-                        world.setBlock(coord.posX, coord.posY, coord.posZ, LittleTiles.blockTile, 0, 3);
-
-                    TileEntity te = world.getTileEntity(coord.posX, coord.posY, coord.posZ);
-                    if (te instanceof TileEntityLittleTiles) {
-                        TileEntityLittleTiles teLT = (TileEntityLittleTiles) te;
-
-                        for (PreviewTile placeTile : placeTiles) {
-
-                            LittleTileCutoutInfo cutoutInfoCurrent = null;
-                            if (cutoutInfo != null) {
-                                LittleTileBox originalBox = previews.get(0).box;
-                                LittleTileBox currentBox = placeTile.box;
-
-                                cutoutInfoCurrent = new LittleTileCutoutInfo(cutoutInfo);
-                                cutoutInfoCurrent.pos.x += (x - coord.posX) * 16 + originalBox.minX - currentBox.minX;
-                                cutoutInfoCurrent.pos.y += (y - coord.posY) * 16 + originalBox.minY - currentBox.minY;
-                                cutoutInfoCurrent.pos.z += (z - coord.posZ) * 16 + originalBox.minZ - currentBox.minZ;
-
-                                Mesh3d mesh = Mesh3dUtil.createMesh(
-                                        0,
-                                        0,
-                                        0,
-                                        cutoutInfoCurrent,
-                                        currentBox.minX / 16.0,
-                                        currentBox.minY / 16.0,
-                                        currentBox.minZ / 16.0,
-                                        currentBox.maxX / 16.0,
-                                        currentBox.maxY / 16.0,
-                                        currentBox.maxZ / 16.0,
-                                        null,
-                                        0);
-                                if (mesh.getTriangles().isEmpty()) {
-                                    continue;
-                                }
-                            }
-
-                            List<LittleTile> tiles = placeTile
-                                    .placeTile(player, stack, teLT, structure, unplaceableTiles, placeMode);
-                            if (tiles != null) {
-                                for (LittleTile LT : tiles) {
-                                    didPlace = true;
-                                    LT.setCutoutInfo(cutoutInfoCurrent);
-                                    if (!soundsToBePlayed.contains(LT.getSound())) soundsToBePlayed.add(LT.getSound());
-                                    if (structure != null) {
-                                        if (pos == null) {
-                                            structure.mainTile = LT;
-                                            LT.isMainBlock = true;
-                                            LT.updateCorner();
-                                            pos = new LittleTilePosition(coord, LT.cornerVec.copy());
-                                        } else LT.coord = new LittleTileCoord(teLT, pos.coord, pos.position);
-                                    }
-                                }
-                            }
-                        }
-
-                        if (structure != null) teLT.combineTiles(structure);
-                    }
-                }
-            }
-            for (SoundType soundType : soundsToBePlayed) {
-                world.playSoundEffect(
-                        (float) player.posX,
-                        (float) player.posY,
-                        (float) player.posZ,
-                        soundType.func_150496_b(),
-                        (soundType.getVolume() + 1.0F) / 2.0F,
-                        soundType.getPitch() * 0.8F);
-            }
-            return didPlace;
+        LittleTilePlacementPlan plan = new LittleTilePlacementPlan();
+        plan.fillPlan(world, x, y, z, previews, structure, placeMode);
+        if (!plan.canApplyPlan()) {
+            return false;
         }
-        return false;
+
+        return plan.applyPlan(world, player, stack, structure, unplaceableTiles, cutoutInfo);
     }
 
     public boolean placeBlockAt(EntityPlayer player, ItemStack stack, World world, LittleTileBlockPos pos,

--- a/src/main/java/com/creativemd/littletiles/common/items/LittleTilePlacementPlan.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/LittleTilePlacementPlan.java
@@ -1,0 +1,251 @@
+package com.creativemd.littletiles.common.items;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.block.Block.SoundType;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ChunkCoordinates;
+import net.minecraft.world.World;
+
+import com.creativemd.creativecore.common.utils.HashMapList;
+import com.creativemd.littletiles.LittleTiles;
+import com.creativemd.littletiles.client.util3d.Mesh3d;
+import com.creativemd.littletiles.client.util3d.Mesh3dUtil;
+import com.creativemd.littletiles.common.blocks.BlockTile;
+import com.creativemd.littletiles.common.structure.LittleStructure;
+import com.creativemd.littletiles.common.tileentity.TileEntityLittleTiles;
+import com.creativemd.littletiles.common.utils.LittleTile;
+import com.creativemd.littletiles.common.utils.LittleTile.LittleTilePosition;
+import com.creativemd.littletiles.common.utils.LittleTileCutoutInfo;
+import com.creativemd.littletiles.common.utils.LittleTilePlaceMode;
+import com.creativemd.littletiles.common.utils.small.LittleTileBox;
+import com.creativemd.littletiles.common.utils.small.LittleTileCoord;
+import com.creativemd.littletiles.utils.PreviewTile;
+
+public class LittleTilePlacementPlan {
+
+    private static class PlacementEntry {
+
+        public final ChunkCoordinates coord;
+        public final ArrayList<PreviewTile> placeTiles;
+
+        public PlacementEntry(ChunkCoordinates coord, ArrayList<PreviewTile> placeTiles) {
+            this.coord = coord;
+            this.placeTiles = placeTiles;
+        }
+    }
+
+    private final ArrayList<PlacementEntry> entries = new ArrayList<>();
+    private final ArrayList<SoundType> soundsToBePlayed = new ArrayList<>();
+    private boolean canApplyPlan;
+    private LittleTilePlaceMode placeMode;
+    private LittleTilePosition structureMainPosition;
+    private int originX;
+    private int originY;
+    private int originZ;
+    private LittleTileBox originalBox;
+
+    public void fillPlan(World world, int x, int y, int z, ArrayList<PreviewTile> previews, LittleStructure structure,
+            LittleTilePlaceMode placeMode) {
+        this.placeMode = placeMode;
+        this.originX = x;
+        this.originY = y;
+        this.originZ = z;
+        if (previews.isEmpty()) {
+            canApplyPlan = false;
+            return;
+        }
+        this.originalBox = previews.get(0).box;
+        boolean specialPlaceMode = placeMode != LittleTilePlaceMode.NORMAL && structure == null;
+        canApplyPlan = tryFillPlan(world, x, y, z, previews, specialPlaceMode);
+    }
+
+    public boolean canApplyPlan() {
+        return canApplyPlan;
+    }
+
+    public boolean applyPlan(World world, EntityPlayer player, ItemStack stack, LittleStructure structure,
+            ArrayList<LittleTile> unplaceableTiles, LittleTileCutoutInfo cutoutInfo) {
+        structureMainPosition = null;
+        soundsToBePlayed.clear();
+        boolean didPlace = false;
+        for (PlacementEntry entry : entries) {
+            TileEntityLittleTiles tile = getOrCreateTileEntity(world, entry);
+            for (PreviewTile placeTile : entry.placeTiles) {
+                didPlace |= applyTile(entry, placeTile, tile, player, stack, structure, unplaceableTiles, cutoutInfo);
+            }
+            if (structure != null) tile.combineTiles(structure);
+        }
+        for (SoundType soundType : soundsToBePlayed) {
+            playTileSound(world, player, soundType);
+        }
+        return didPlace;
+    }
+
+    private boolean tryFillPlan(World world, int x, int y, int z, ArrayList<PreviewTile> previews,
+            boolean specialPlaceMode) {
+        entries.clear();
+
+        HashMapList<ChunkCoordinates, PreviewTile> splittedTiles = getSplittedTiles(previews, x, y, z);
+        if (splittedTiles == null) return false;
+
+        // specialPlaceMode means: place what fits, handle overlaps in a custom fashion
+        // Otherwise placement is atomic — any unplaceable coord rejects the whole plan
+        for (int i = 0; i < splittedTiles.size(); i++) {
+            ChunkCoordinates coord = splittedTiles.getKey(i);
+            ArrayList<PreviewTile> placeTiles = splittedTiles.getValues(i);
+            TileEntityLittleTiles tile = getTileEntity(world, coord);
+
+            // The coord is usable if it already hosts a LittleTiles TE (we'll merge into it) or holds a
+            // replaceable non-BlockTile we can overwrite. Anything else (solid block, BlockTile without a
+            // TE, out of world) is fundamentally not placeable — special place mode can't fix that, only skip it.
+            boolean canPlaceHere = tile != null || canCreateBlockTile(world, coord);
+            if (!canPlaceHere) {
+                if (specialPlaceMode) continue;
+                return false;
+            }
+
+            // Previews that don't need a collision test are markers/visual-only and never get placed.
+            if (placeTiles == null || !needsCollisionTest(placeTiles)) continue;
+
+            // Collision check against an existing LittleTiles TE. Special place mode bypasses this on
+            // purpose — overriding collisions is its whole reason to exist.
+            if (!specialPlaceMode && tile != null && !isSpaceForTiles(tile, placeTiles)) {
+                return false;
+            }
+
+            entries.add(new PlacementEntry(coord, placeTiles));
+        }
+        return true;
+    }
+
+    private static HashMapList<ChunkCoordinates, PreviewTile> getSplittedTiles(ArrayList<PreviewTile> tiles, int x,
+            int y, int z) {
+        HashMapList<ChunkCoordinates, PreviewTile> splitted = new HashMapList<>();
+        for (PreviewTile tile : tiles) {
+            if (!tile.split(splitted, x, y, z)) return null;
+        }
+        return splitted;
+    }
+
+    private static boolean needsCollisionTest(ArrayList<PreviewTile> placeTiles) {
+        for (PreviewTile tile : placeTiles) {
+            if (tile.needsCollisionTest()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static TileEntityLittleTiles getTileEntity(World world, ChunkCoordinates coord) {
+        TileEntity te = world.getTileEntity(coord.posX, coord.posY, coord.posZ);
+        if (te instanceof TileEntityLittleTiles lte) {
+            return lte;
+        }
+        return null;
+    }
+
+    private boolean applyTile(PlacementEntry entry, PreviewTile placeTile, TileEntityLittleTiles tile,
+            EntityPlayer player, ItemStack stack, LittleStructure structure, ArrayList<LittleTile> unplaceableTiles,
+            LittleTileCutoutInfo cutoutInfo) {
+        LittleTileCutoutInfo cutoutInfoCurrent = getCutoutInfoCurrent(entry, placeTile, cutoutInfo);
+        if (cutoutInfo != null && cutoutInfoCurrent == null) {
+            return false;
+        }
+
+        List<LittleTile> tiles = placeTile.placeTile(player, stack, tile, structure, unplaceableTiles, placeMode);
+        if (tiles == null) {
+            return false;
+        }
+
+        boolean didPlace = false;
+        for (LittleTile littleTile : tiles) {
+            didPlace = true;
+            littleTile.setCutoutInfo(cutoutInfoCurrent);
+            if (structure != null) {
+                if (structureMainPosition == null) {
+                    structure.mainTile = littleTile;
+                    littleTile.isMainBlock = true;
+                    littleTile.updateCorner();
+                    structureMainPosition = new LittleTilePosition(entry.coord, littleTile.cornerVec.copy());
+                } else {
+                    littleTile.coord = new LittleTileCoord(
+                            tile,
+                            structureMainPosition.coord,
+                            structureMainPosition.position);
+                }
+            }
+            if (!soundsToBePlayed.contains(littleTile.getSound())) soundsToBePlayed.add(littleTile.getSound());
+        }
+        return didPlace;
+    }
+
+    private LittleTileCutoutInfo getCutoutInfoCurrent(PlacementEntry entry, PreviewTile placeTile,
+            LittleTileCutoutInfo cutoutInfo) {
+        if (cutoutInfo == null) {
+            return null;
+        }
+
+        LittleTileBox currentBox = placeTile.box;
+
+        LittleTileCutoutInfo cutoutInfoCurrent = new LittleTileCutoutInfo(cutoutInfo);
+        cutoutInfoCurrent.pos.x += (originX - entry.coord.posX) * 16 + originalBox.minX - currentBox.minX;
+        cutoutInfoCurrent.pos.y += (originY - entry.coord.posY) * 16 + originalBox.minY - currentBox.minY;
+        cutoutInfoCurrent.pos.z += (originZ - entry.coord.posZ) * 16 + originalBox.minZ - currentBox.minZ;
+
+        Mesh3d mesh = Mesh3dUtil.createMesh(
+                0,
+                0,
+                0,
+                cutoutInfoCurrent,
+                currentBox.minX / 16.0,
+                currentBox.minY / 16.0,
+                currentBox.minZ / 16.0,
+                currentBox.maxX / 16.0,
+                currentBox.maxY / 16.0,
+                currentBox.maxZ / 16.0,
+                null,
+                0);
+        if (mesh.getTriangles().isEmpty()) {
+            return null;
+        }
+        return cutoutInfoCurrent;
+    }
+
+    private static void playTileSound(World world, EntityPlayer player, SoundType soundType) {
+        world.playSoundEffect(
+                (float) player.posX,
+                (float) player.posY,
+                (float) player.posZ,
+                soundType.func_150496_b(),
+                (soundType.getVolume() + 1.0F) / 2.0F,
+                soundType.getPitch() * 0.8F);
+    }
+
+    private static TileEntityLittleTiles getOrCreateTileEntity(World world, PlacementEntry entry) {
+        ChunkCoordinates coord = entry.coord;
+        if (canCreateBlockTile(world, coord)) {
+            world.setBlock(coord.posX, coord.posY, coord.posZ, LittleTiles.blockTile, 0, 3);
+        }
+
+        TileEntityLittleTiles tile = getTileEntity(world, coord);
+        if (tile == null) {
+            throw new IllegalStateException("Failed to resolve LittleTiles tile entity for placement plan");
+        }
+        return tile;
+    }
+
+    private static boolean canCreateBlockTile(World world, ChunkCoordinates coord) {
+        return !(world.getBlock(coord.posX, coord.posY, coord.posZ) instanceof BlockTile)
+                && world.getBlock(coord.posX, coord.posY, coord.posZ).getMaterial().isReplaceable();
+    }
+
+    private static boolean isSpaceForTiles(TileEntityLittleTiles mainTile, ArrayList<PreviewTile> placeTiles) {
+        for (PreviewTile tile : placeTiles)
+            if (tile.needsCollisionTest() && !(mainTile).isSpaceForLittleTile(tile.box)) return false;
+        return true;
+    }
+}

--- a/src/main/java/com/creativemd/littletiles/common/items/LittleTilePlacementPlan.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/LittleTilePlacementPlan.java
@@ -3,6 +3,7 @@ package com.creativemd.littletiles.common.items;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.Block.SoundType;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -74,6 +75,9 @@ public class LittleTilePlacementPlan {
         boolean didPlace = false;
         for (PlacementEntry entry : entries) {
             TileEntityLittleTiles tile = getOrCreateTileEntity(world, entry);
+            if (tile == null) {
+                continue;
+            }
             for (PreviewTile placeTile : entry.placeTiles) {
                 didPlace |= applyTile(entry, placeTile, tile, player, stack, structure, unplaceableTiles, cutoutInfo);
             }
@@ -98,11 +102,11 @@ public class LittleTilePlacementPlan {
             ChunkCoordinates coord = splittedTiles.getKey(i);
             ArrayList<PreviewTile> placeTiles = splittedTiles.getValues(i);
             TileEntityLittleTiles tile = getTileEntity(world, coord);
+            Block block = world.getBlock(coord.posX, coord.posY, coord.posZ);
 
             // The coord is usable if it already hosts a LittleTiles TE (we'll merge into it) or holds a
-            // replaceable non-BlockTile we can overwrite. Anything else (solid block, BlockTile without a
-            // TE, out of world) is fundamentally not placeable — special place mode can't fix that, only skip it.
-            boolean canPlaceHere = tile != null || canCreateBlockTile(world, coord);
+            // replaceable non-BlockTile we can overwrite.
+            boolean canPlaceHere = tile != null || (!(block instanceof BlockTile) && block.getMaterial().isReplaceable());
             if (!canPlaceHere) {
                 if (specialPlaceMode) continue;
                 return false;
@@ -227,20 +231,18 @@ public class LittleTilePlacementPlan {
 
     private static TileEntityLittleTiles getOrCreateTileEntity(World world, PlacementEntry entry) {
         ChunkCoordinates coord = entry.coord;
-        if (canCreateBlockTile(world, coord)) {
-            world.setBlock(coord.posX, coord.posY, coord.posZ, LittleTiles.blockTile, 0, 3);
-        }
-
         TileEntityLittleTiles tile = getTileEntity(world, coord);
-        if (tile == null) {
-            throw new IllegalStateException("Failed to resolve LittleTiles tile entity for placement plan");
+        if (tile != null) {
+            return tile;
         }
-        return tile;
-    }
 
-    private static boolean canCreateBlockTile(World world, ChunkCoordinates coord) {
-        return !(world.getBlock(coord.posX, coord.posY, coord.posZ) instanceof BlockTile)
-                && world.getBlock(coord.posX, coord.posY, coord.posZ).getMaterial().isReplaceable();
+        world.setBlock(coord.posX, coord.posY, coord.posZ, LittleTiles.blockTile, 0, 3);
+        tile = getTileEntity(world, coord);
+        if (tile != null) {
+            return tile;
+        }
+
+        return null;
     }
 
     private static boolean isSpaceForTiles(TileEntityLittleTiles mainTile, ArrayList<PreviewTile> placeTiles) {

--- a/src/main/java/com/creativemd/littletiles/common/items/LittleTilePlacementPlan.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/LittleTilePlacementPlan.java
@@ -106,7 +106,8 @@ public class LittleTilePlacementPlan {
 
             // The coord is usable if it already hosts a LittleTiles TE (we'll merge into it) or holds a
             // replaceable non-BlockTile we can overwrite.
-            boolean canPlaceHere = tile != null || (!(block instanceof BlockTile) && block.getMaterial().isReplaceable());
+            boolean canPlaceHere = tile != null
+                    || (!(block instanceof BlockTile) && block.getMaterial().isReplaceable());
             if (!canPlaceHere) {
                 if (specialPlaceMode) continue;
                 return false;

--- a/src/main/java/com/creativemd/littletiles/common/items/LittleTilePlacementPlan.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/LittleTilePlacementPlan.java
@@ -104,6 +104,10 @@ public class LittleTilePlacementPlan {
             TileEntityLittleTiles tile = getTileEntity(world, coord);
             Block block = world.getBlock(coord.posX, coord.posY, coord.posZ);
 
+            // STENCIL only removes overlapping tiles, so it needs an existing TE — otherwise we'd stamp
+            // an empty BlockTile onto air. Skip the coord rather than rejecting the whole plan.
+            if (placeMode == LittleTilePlaceMode.STENCIL && tile == null) continue;
+
             // The coord is usable if it already hosts a LittleTiles TE (we'll merge into it) or holds a
             // replaceable non-BlockTile we can overwrite.
             boolean canPlaceHere = tile != null

--- a/src/main/java/com/creativemd/littletiles/utils/PreviewTile.java
+++ b/src/main/java/com/creativemd/littletiles/utils/PreviewTile.java
@@ -76,16 +76,20 @@ public class PreviewTile {
         for (LittleTile t : tiles) {
             if (t.overlapsTile(tileNew)) {
                 newTiles.addAll(t.splitByTile(tileNew));
-                boolean cleanUpTileEntity = newTiles.isEmpty();
-                t.destroy(cleanUpTileEntity);
+                t.destroy(false);
             }
         }
         if (doAdd) {
             newTiles.add(tileNew);
         }
+
         for (LittleTile tile : newTiles) {
             tile.place();
             tile.onPlaced(player, stack);
+        }
+        if (newTiles.isEmpty()) {
+            // Trigger cleanup in case tile is empty
+            tileNew.te.updateTiles();
         }
         return newTiles;
     }


### PR DESCRIPTION
This PR
- avoids leaving empty little tiles blocks around, they should be replaced with air once the last tile is removed
- Fixes not placing tiles if we overwrite all existing tiles, since it got destroyed prematurely.