### PR TITLE
Don't use rock material

### DIFF
--- a/src/main/java/com/creativemd/littletiles/LittleTiles.java
+++ b/src/main/java/com/creativemd/littletiles/LittleTiles.java
@@ -1,6 +1,7 @@
 package com.creativemd.littletiles;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
@@ -74,10 +75,11 @@ public class LittleTiles {
     public static int maxNewTiles = 512;
 
     public static CreativeTabs creativeTabLittleTiles = new LittleTilesCreativeTab("littletiles");
+    private static final Material materialLittleTile = new Material(MapColor.stoneColor);
 
-    public static BlockTile blockTile = (BlockTile) new BlockTile(Material.rock).setBlockName("LTTile")
+    public static BlockTile blockTile = (BlockTile) new BlockTile(materialLittleTile).setBlockName("LTTile")
             .setCreativeTab(creativeTabLittleTiles);
-    public static Block coloredBlock = new BlockLTColored().setBlockName("LTBlocks")
+    public static Block coloredBlock = new BlockLTColored(materialLittleTile).setBlockName("LTBlocks")
             .setCreativeTab(creativeTabLittleTiles);
 
     public static Item hammer = new ItemHammer().setUnlocalizedName("LTHammer").setCreativeTab(creativeTabLittleTiles);

--- a/src/main/java/com/creativemd/littletiles/common/blocks/BlockLTColored.java
+++ b/src/main/java/com/creativemd/littletiles/common/blocks/BlockLTColored.java
@@ -17,8 +17,8 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 public class BlockLTColored extends Block {
 
-    public BlockLTColored() {
-        super(Material.rock);
+    public BlockLTColored(Material material) {
+        super(material);
         this.setBlockTextureName(LittleTiles.modid + ":LTColored0");
         setCreativeTab(CreativeTabs.tabTools);
     }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/22023

The Tinkers hammer is allowed to break rock material, but there is no reason for our little tiles block to be of rock material. Breaking little tiles themselves still uses the correct material, since it uses the material the tile is actually made of.