### PR TITLE
Fix marked slope

### DIFF
--- a/src/main/java/com/creativemd/littletiles/common/items/ItemBlockTiles.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemBlockTiles.java
@@ -109,6 +109,7 @@ public class ItemBlockTiles extends ItemBlock implements ILittleTile, ITilesRend
                     PreviewRenderer.firstHit = pos;
                     return true;
                 }
+                cutoutInfo = LittleTileCutoutInfo.fromItemStack(stack, pos, pos);
             } else {
                 cutoutInfo = LittleTileCutoutInfo.fromItemStack(stack, PreviewRenderer.firstHit, pos);
 


### PR DESCRIPTION
If you use the chisel and use marked mode, it places only a single tile. This doesn't work currently with slopes - they get placed as full block instead. This PR fixes this oversight.