### PR TITLE
Slope placement

### DIFF
--- a/src/main/java/com/creativemd/littletiles/client/util3d/Mesh3d.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/Mesh3d.java
@@ -10,6 +10,7 @@ import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import org.joml.Vector3f;
 import org.joml.Vector3i;
 
 import com.creativemd.creativecore.lib.Vector3d;
@@ -287,6 +288,17 @@ public class Mesh3d {
             if (trianglePoints.contains(point)) {
                 ret.add(point);
             }
+        }
+        return ret;
+    }
+
+    public Vector3f[] getVertices() {
+        Vector3f[] ret = new Vector3f[triangles.size() * 3];
+        for (int i = 0; i < triangles.size(); i++) {
+            Triangle3d triangle = triangles.get(i);
+            ret[i * 3] = triangle.getP1().toVector3f();
+            ret[i * 3 + 1] = triangle.getP2().toVector3f();
+            ret[i * 3 + 2] = triangle.getP3().toVector3f();
         }
         return ret;
     }

--- a/src/main/java/com/creativemd/littletiles/client/util3d/TriangleBoundingBoxIntersect.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/TriangleBoundingBoxIntersect.java
@@ -1,48 +1,42 @@
 package com.creativemd.littletiles.client.util3d;/*
- * Copyright (c) 2009-2010 jMonkeyEngine
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are
- * met:
- *
- * * Redistributions of source code must retain the above copyright
- *   notice, this list of conditions and the following disclaimer.
- *
- * * Redistributions in binary form must reproduce the above copyright
- *   notice, this list of conditions and the following disclaimer in the
- *   documentation and/or other materials provided with the distribution.
- *
- * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
- *   may be used to endorse or promote products derived from this software
- *   without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
- * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
- * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+                                                  * Copyright (c) 2009-2010 jMonkeyEngine All rights reserved.
+                                                  * Redistribution and use in source and binary forms, with or without
+                                                  * modification, are permitted provided that the following conditions
+                                                  * are met: * Redistributions of source code must retain the above
+                                                  * copyright notice, this list of conditions and the following
+                                                  * disclaimer. * Redistributions in binary form must reproduce the
+                                                  * above copyright notice, this list of conditions and the following
+                                                  * disclaimer in the documentation and/or other materials provided with
+                                                  * the distribution. * Neither the name of 'jMonkeyEngine' nor the
+                                                  * names of its contributors may be used to endorse or promote products
+                                                  * derived from this software without specific prior written
+                                                  * permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+                                                  * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+                                                  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+                                                  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+                                                  * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+                                                  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+                                                  * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+                                                  * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+                                                  * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+                                                  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+                                                  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+                                                  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+                                                  */
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 
 import org.joml.Vector3f;
 
-import static java.lang.Math.min;
-import static java.lang.Math.max;
-
 /**
- * This class includes some utility methods for computing intersection
- * between bounding volumes and triangles.
+ * This class includes some utility methods for computing intersection between bounding volumes and triangles.
+ * 
  * @author Kirill
  */
 public class TriangleBoundingBoxIntersect {
 
-    private static void findMinMax(float f1, float f2, float f3, Vector3f minMax){
+    private static void findMinMax(float f1, float f2, float f3, Vector3f minMax) {
         minMax.set(f1, f1, 0);
         if (f2 < minMax.x) minMax.x = f2;
         if (f2 > minMax.y) minMax.y = f2;
@@ -50,27 +44,25 @@ public class TriangleBoundingBoxIntersect {
         if (f3 > minMax.y) minMax.y = f3;
     }
 
-    public static boolean intersect(BoundingBox bbox, Vector3f v1, Vector3f v2, Vector3f v3){
-        //  use separating axis theorem to test overlap between triangle and box
-        //  need to test for overlap in these directions:
-        //  1) the {x,y,z}-directions (actually, since we use the AABB of the triangle
-        //     we do not even need to test these)
-        //  2) normal of the triangle
-        //  3) crossproduct(edge from tri, {x,y,z}-directin)
-        //       this gives 3x3=9 more tests
-
+    public static boolean intersect(BoundingBox bbox, Vector3f v1, Vector3f v2, Vector3f v3) {
+        // use separating axis theorem to test overlap between triangle and box
+        // need to test for overlap in these directions:
+        // 1) the {x,y,z}-directions (actually, since we use the AABB of the triangle
+        // we do not even need to test these)
+        // 2) normal of the triangle
+        // 3) crossproduct(edge from tri, {x,y,z}-directin)
+        // this gives 3x3=9 more tests
 
         Vector3f tmp0 = new Vector3f();
-        Vector3f tmp1 =  new Vector3f();
-        Vector3f tmp2 =  new Vector3f();
+        Vector3f tmp1 = new Vector3f();
+        Vector3f tmp2 = new Vector3f();
 
-        Vector3f e0 =  new Vector3f();
-        Vector3f e1 =  new Vector3f();
-        Vector3f e2 =  new Vector3f();
+        Vector3f e0 = new Vector3f();
+        Vector3f e1 = new Vector3f();
+        Vector3f e2 = new Vector3f();
 
         Vector3f center = bbox.getCenter();
         Vector3f extent = bbox.getExtent();
-
 
         // This is the fastest branch on Sun
         // move everything so that the boxcenter is in (0,0,0)
@@ -84,42 +76,40 @@ public class TriangleBoundingBoxIntersect {
         tmp0.sub(tmp2, e2); // tri edge 2
 
         // Bullet 3:
-        //  test the 9 tests first (this was faster)
+        // test the 9 tests first (this was faster)
         float min, max;
         float p0, p1, p2, rad;
         float fex = Math.abs(e0.x);
         float fey = Math.abs(e0.y);
         float fez = Math.abs(e0.z);
 
-
-
-        //AXISTEST_X01(e0[Z], e0[Y], fez, fey);
+        // AXISTEST_X01(e0[Z], e0[Y], fez, fey);
         p0 = e0.z * tmp0.y - e0.y * tmp0.z;
         p2 = e0.z * tmp2.y - e0.y * tmp2.z;
-        min = min(p0,p2);
-        max = max(p0,p2);
+        min = min(p0, p2);
+        max = max(p0, p2);
         rad = fez * extent.y + fey * extent.z;
-        if (min > rad || max < -rad){
+        if (min > rad || max < -rad) {
             return false;
         }
 
-        //   AXISTEST_Y02(e0[Z], e0[X], fez, fex);
+        // AXISTEST_Y02(e0[Z], e0[X], fez, fex);
         p0 = -e0.z * tmp0.x + e0.x * tmp0.z;
         p2 = -e0.z * tmp2.x + e0.x * tmp2.z;
-        min = min(p0,p2);
-        max = max(p0,p2);
+        min = min(p0, p2);
+        max = max(p0, p2);
         rad = fez * extent.x + fex * extent.z;
-        if (min > rad || max < -rad){
+        if (min > rad || max < -rad) {
             return false;
         }
 
         // AXISTEST_Z12(e0[Y], e0[X], fey, fex);
         p1 = e0.y * tmp1.x - e0.x * tmp1.y;
         p2 = e0.y * tmp2.x - e0.x * tmp2.y;
-        min = min(p1,p2);
-        max = max(p1,p2);
+        min = min(p1, p2);
+        max = max(p1, p2);
         rad = fey * extent.x + fex * extent.y;
-        if (min > rad || max < -rad){
+        if (min > rad || max < -rad) {
             return false;
         }
 
@@ -127,36 +117,36 @@ public class TriangleBoundingBoxIntersect {
         fey = Math.abs(e1.y);
         fez = Math.abs(e1.z);
 
-//        AXISTEST_X01(e1[Z], e1[Y], fez, fey);
+        // AXISTEST_X01(e1[Z], e1[Y], fez, fey);
         p0 = e1.z * tmp0.y - e1.y * tmp0.z;
         p2 = e1.z * tmp2.y - e1.y * tmp2.z;
-        min = min(p0,p2);
-        max = max(p0,p2);
+        min = min(p0, p2);
+        max = max(p0, p2);
         rad = fez * extent.y + fey * extent.z;
-        if (min > rad || max < -rad){
+        if (min > rad || max < -rad) {
             return false;
         }
 
-        //   AXISTEST_Y02(e1[Z], e1[X], fez, fex);
+        // AXISTEST_Y02(e1[Z], e1[X], fez, fex);
         p0 = -e1.z * tmp0.x + e1.x * tmp0.z;
         p2 = -e1.z * tmp2.x + e1.x * tmp2.z;
-        min = min(p0,p2);
-        max = max(p0,p2);
+        min = min(p0, p2);
+        max = max(p0, p2);
         rad = fez * extent.x + fex * extent.z;
-        if (min > rad || max < -rad){
+        if (min > rad || max < -rad) {
             return false;
         }
 
         // AXISTEST_Z0(e1[Y], e1[X], fey, fex);
         p0 = e1.y * tmp0.x - e1.x * tmp0.y;
         p1 = e1.y * tmp1.x - e1.x * tmp1.y;
-        min = min(p0,p1);
-        max = max(p0,p1);
+        min = min(p0, p1);
+        max = max(p0, p1);
         rad = fey * extent.x + fex * extent.y;
-        if (min > rad || max < -rad){
+        if (min > rad || max < -rad) {
             return false;
         }
-//
+        //
         fex = Math.abs(e2.x);
         fey = Math.abs(e2.y);
         fez = Math.abs(e2.z);
@@ -164,77 +154,76 @@ public class TriangleBoundingBoxIntersect {
         // AXISTEST_X2(e2[Z], e2[Y], fez, fey);
         p0 = e2.z * tmp0.y - e2.y * tmp0.z;
         p1 = e2.z * tmp1.y - e2.y * tmp1.z;
-        min = min(p0,p1);
-        max = max(p0,p1);
+        min = min(p0, p1);
+        max = max(p0, p1);
         rad = fez * extent.y + fey * extent.z;
-        if (min > rad || max < -rad){
+        if (min > rad || max < -rad) {
             return false;
         }
 
         // AXISTEST_Y1(e2[Z], e2[X], fez, fex);
         p0 = -e2.z * tmp0.x + e2.x * tmp0.z;
         p1 = -e2.z * tmp1.x + e2.x * tmp1.z;
-        min = min(p0,p1);
-        max = max(p0,p1);
+        min = min(p0, p1);
+        max = max(p0, p1);
         rad = fez * extent.x + fex * extent.y;
-        if (min > rad || max < -rad){
+        if (min > rad || max < -rad) {
             return false;
         }
 
-//   AXISTEST_Z12(e2[Y], e2[X], fey, fex);
+        // AXISTEST_Z12(e2[Y], e2[X], fey, fex);
         p1 = e2.y * tmp1.x - e2.x * tmp1.y;
         p2 = e2.y * tmp2.x - e2.x * tmp2.y;
-        min = min(p1,p2);
-        max = max(p1,p2);
+        min = min(p1, p2);
+        max = max(p1, p2);
         rad = fey * extent.x + fex * extent.y;
-        if (min > rad || max < -rad){
+        if (min > rad || max < -rad) {
             return false;
         }
 
-        //  Bullet 1:
-        //  first test overlap in the {x,y,z}-directions
-        //  find min, max of the triangle each direction, and test for overlap in
-        //  that direction -- this is equivalent to testing a minimal AABB around
-        //  the triangle against the AABB
-
+        // Bullet 1:
+        // first test overlap in the {x,y,z}-directions
+        // find min, max of the triangle each direction, and test for overlap in
+        // that direction -- this is equivalent to testing a minimal AABB around
+        // the triangle against the AABB
 
         Vector3f minMax = new Vector3f();
 
         // test in X-direction
         findMinMax(tmp0.x, tmp1.x, tmp2.x, minMax);
-        if(minMax.x > extent.x || minMax.y < -extent.x){
+        if (minMax.x > extent.x || minMax.y < -extent.x) {
             return false;
         }
 
         // test in Y-direction
         findMinMax(tmp0.y, tmp1.y, tmp2.y, minMax);
-        if(minMax.x > extent.y || minMax.y < -extent.y){
+        if (minMax.x > extent.y || minMax.y < -extent.y) {
             return false;
         }
 
         // test in Z-direction
         findMinMax(tmp0.z, tmp1.z, tmp2.z, minMax);
-        if(minMax.x > extent.z || minMax.y < -extent.z){
+        if (minMax.x > extent.z || minMax.y < -extent.z) {
             return false;
         }
 
-//       // Bullet 2:
-//       //  test if the box intersects the plane of the triangle
-//       //  compute plane equation of triangle: normal * x + d = 0
-//        Vector3f normal = new Vector3f();
-//        e0.cross(e1, normal);
+        // // Bullet 2:
+        // // test if the box intersects the plane of the triangle
+        // // compute plane equation of triangle: normal * x + d = 0
+        // Vector3f normal = new Vector3f();
+        // e0.cross(e1, normal);
         Plane p = new Plane();
 
-        p.setPlanePoints(v1,v2,v3);
-        if (bbox.whichSide(p) == Plane.Side.Negative){
+        p.setPlanePoints(v1, v2, v3);
+        if (bbox.whichSide(p) == Plane.Side.Negative) {
             return false;
         }
 
-        return true;   /* box and triangle overlaps */
+        return true; /* box and triangle overlaps */
     }
 
-    public static class BoundingBox
-    {
+    public static class BoundingBox {
+
         private final Vector3f center;
         private final Vector3f extend;
 
@@ -252,13 +241,12 @@ public class TriangleBoundingBoxIntersect {
         }
 
         public Plane.Side whichSide(Plane plane) {
-            float radius = Math.abs(extend.x * plane.getNormal().x)
-                + Math.abs(extend.y * plane.getNormal().y)
-                + Math.abs(extend.z * plane.getNormal().z);
+            float radius = Math.abs(extend.x * plane.getNormal().x) + Math.abs(extend.y * plane.getNormal().y)
+                    + Math.abs(extend.z * plane.getNormal().z);
 
             float distance = plane.pseudoDistance(center);
 
-            //changed to < and > to prevent floating point precision problems
+            // changed to < and > to prevent floating point precision problems
             if (distance < -radius) {
                 return Plane.Side.Negative;
             } else if (distance > radius) {
@@ -269,8 +257,8 @@ public class TriangleBoundingBoxIntersect {
         }
     }
 
-    public static class Plane
-    {
+    public static class Plane {
+
         public enum Side {
             None,
             Positive,
@@ -279,7 +267,6 @@ public class TriangleBoundingBoxIntersect {
 
         private Vector3f normal;
         private float constant;
-
 
         public void setPlanePoints(Vector3f v1, Vector3f v2, Vector3f v3) {
             normal.set(v2).sub(v1);

--- a/src/main/java/com/creativemd/littletiles/client/util3d/TriangleBoundingBoxIntersect.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/TriangleBoundingBoxIntersect.java
@@ -30,10 +30,7 @@ package com.creativemd.littletiles.client.util3d;/*
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.jme3.util.TempVars;
-import com.jme3.math.FastMath;
-import com.jme3.math.Plane;
-import com.jme3.math.Vector3f;
+import org.joml.Vector3f;
 
 import static java.lang.Math.min;
 import static java.lang.Math.max;
@@ -45,32 +42,13 @@ import static java.lang.Math.max;
  */
 public class TriangleBoundingBoxIntersect {
 
-    private static final void findMinMax(float x0, float x1, float x2, Vector3f minMax){
-        minMax.set(x0, x0, 0);
-        if (x1 < minMax.x) minMax.setX(x1);
-        if (x1 > minMax.y) minMax.setY(x1);
-        if (x2 < minMax.x) minMax.setX(x2);
-        if (x2 > minMax.y) minMax.setY(x2);
+    private static void findMinMax(float f1, float f2, float f3, Vector3f minMax){
+        minMax.set(f1, f1, 0);
+        if (f2 < minMax.x) minMax.x = f2;
+        if (f2 > minMax.y) minMax.y = f2;
+        if (f3 < minMax.x) minMax.x = f3;
+        if (f3 > minMax.y) minMax.y = f3;
     }
-
-//    private boolean axisTest(float a, float b, float fa, float fb, Vector3f v0, Vector3f v1, )
-
-//    private boolean axisTestX01(float a, float b, float fa, float fb,
-//                             Vector3f center, Vector3f ext,
-//                             Vector3f v1, Vector3f v2, Vector3f v3){
-//	float p0 = a * v0.y - b * v0.z;
-//	float p2 = a * v2.y - b * v2.z;
-//        if(p0 < p2){
-//            min = p0;
-//            max = p2;
-//        } else {
-//            min = p2;
-//            max = p0;
-//        }
-//	float rad = fa * boxhalfsize.y + fb * boxhalfsize.z;
-//	if(min > rad || max < -rad)
-//            return false;
-//    }
 
     public static boolean intersect(BoundingBox bbox, Vector3f v1, Vector3f v2, Vector3f v3){
         //  use separating axis theorem to test overlap between triangle and box
@@ -81,41 +59,37 @@ public class TriangleBoundingBoxIntersect {
         //  3) crossproduct(edge from tri, {x,y,z}-directin)
         //       this gives 3x3=9 more tests
 
-        TempVars vars = TempVars.get();
-        assert vars.lock();
 
-        Vector3f tmp0 = vars.vect1,
-            tmp1 = vars.vect2,
-            tmp2 = vars.vect3;
+        Vector3f tmp0 = new Vector3f();
+        Vector3f tmp1 =  new Vector3f();
+        Vector3f tmp2 =  new Vector3f();
 
-        Vector3f e0 = vars.vect4,
-            e1 = vars.vect5,
-            e2 = vars.vect6;
+        Vector3f e0 =  new Vector3f();
+        Vector3f e1 =  new Vector3f();
+        Vector3f e2 =  new Vector3f();
 
         Vector3f center = bbox.getCenter();
-        Vector3f extent = bbox.getExtent(null);
+        Vector3f extent = bbox.getExtent();
 
-//   float min,max,p0,p1,p2,rad,fex,fey,fez;
-//   float normal[3]
 
         // This is the fastest branch on Sun
         // move everything so that the boxcenter is in (0,0,0)
-        v1.subtract(center, tmp0);
-        v2.subtract(center, tmp1);
-        v3.subtract(center, tmp2);
+        v1.sub(center, tmp0);
+        v2.sub(center, tmp1);
+        v3.sub(center, tmp2);
 
         // compute triangle edges
-        tmp1.subtract(tmp0, e0); // tri edge 0
-        tmp2.subtract(tmp1, e1); // tri edge 1
-        tmp0.subtract(tmp2, e2); // tri edge 2
+        tmp1.sub(tmp0, e0); // tri edge 0
+        tmp2.sub(tmp1, e1); // tri edge 1
+        tmp0.sub(tmp2, e2); // tri edge 2
 
         // Bullet 3:
         //  test the 9 tests first (this was faster)
         float min, max;
         float p0, p1, p2, rad;
-        float fex = FastMath.abs(e0.x);
-        float fey = FastMath.abs(e0.y);
-        float fez = FastMath.abs(e0.z);
+        float fex = Math.abs(e0.x);
+        float fey = Math.abs(e0.y);
+        float fez = Math.abs(e0.z);
 
 
 
@@ -126,7 +100,6 @@ public class TriangleBoundingBoxIntersect {
         max = max(p0,p2);
         rad = fez * extent.y + fey * extent.z;
         if (min > rad || max < -rad){
-            assert vars.unlock();
             return false;
         }
 
@@ -137,7 +110,6 @@ public class TriangleBoundingBoxIntersect {
         max = max(p0,p2);
         rad = fez * extent.x + fex * extent.z;
         if (min > rad || max < -rad){
-            assert vars.unlock();
             return false;
         }
 
@@ -148,13 +120,12 @@ public class TriangleBoundingBoxIntersect {
         max = max(p1,p2);
         rad = fey * extent.x + fex * extent.y;
         if (min > rad || max < -rad){
-            assert vars.unlock();
             return false;
         }
 
-        fex = FastMath.abs(e1.x);
-        fey = FastMath.abs(e1.y);
-        fez = FastMath.abs(e1.z);
+        fex = Math.abs(e1.x);
+        fey = Math.abs(e1.y);
+        fez = Math.abs(e1.z);
 
 //        AXISTEST_X01(e1[Z], e1[Y], fez, fey);
         p0 = e1.z * tmp0.y - e1.y * tmp0.z;
@@ -163,7 +134,6 @@ public class TriangleBoundingBoxIntersect {
         max = max(p0,p2);
         rad = fez * extent.y + fey * extent.z;
         if (min > rad || max < -rad){
-            assert vars.unlock();
             return false;
         }
 
@@ -174,7 +144,6 @@ public class TriangleBoundingBoxIntersect {
         max = max(p0,p2);
         rad = fez * extent.x + fex * extent.z;
         if (min > rad || max < -rad){
-            assert vars.unlock();
             return false;
         }
 
@@ -185,13 +154,12 @@ public class TriangleBoundingBoxIntersect {
         max = max(p0,p1);
         rad = fey * extent.x + fex * extent.y;
         if (min > rad || max < -rad){
-            assert vars.unlock();
             return false;
         }
 //
-        fex = FastMath.abs(e2.x);
-        fey = FastMath.abs(e2.y);
-        fez = FastMath.abs(e2.z);
+        fex = Math.abs(e2.x);
+        fey = Math.abs(e2.y);
+        fez = Math.abs(e2.z);
 
         // AXISTEST_X2(e2[Z], e2[Y], fez, fey);
         p0 = e2.z * tmp0.y - e2.y * tmp0.z;
@@ -200,7 +168,6 @@ public class TriangleBoundingBoxIntersect {
         max = max(p0,p1);
         rad = fez * extent.y + fey * extent.z;
         if (min > rad || max < -rad){
-            assert vars.unlock();
             return false;
         }
 
@@ -211,7 +178,6 @@ public class TriangleBoundingBoxIntersect {
         max = max(p0,p1);
         rad = fez * extent.x + fex * extent.y;
         if (min > rad || max < -rad){
-            assert vars.unlock();
             return false;
         }
 
@@ -222,7 +188,6 @@ public class TriangleBoundingBoxIntersect {
         max = max(p1,p2);
         rad = fey * extent.x + fex * extent.y;
         if (min > rad || max < -rad){
-            assert vars.unlock();
             return false;
         }
 
@@ -233,26 +198,23 @@ public class TriangleBoundingBoxIntersect {
         //  the triangle against the AABB
 
 
-        Vector3f minMax = vars.vect7;
+        Vector3f minMax = new Vector3f();
 
         // test in X-direction
         findMinMax(tmp0.x, tmp1.x, tmp2.x, minMax);
         if(minMax.x > extent.x || minMax.y < -extent.x){
-            assert vars.unlock();
             return false;
         }
 
         // test in Y-direction
         findMinMax(tmp0.y, tmp1.y, tmp2.y, minMax);
         if(minMax.x > extent.y || minMax.y < -extent.y){
-            assert vars.unlock();
             return false;
         }
 
         // test in Z-direction
         findMinMax(tmp0.z, tmp1.z, tmp2.z, minMax);
         if(minMax.x > extent.z || minMax.y < -extent.z){
-            assert vars.unlock();
             return false;
         }
 
@@ -261,19 +223,77 @@ public class TriangleBoundingBoxIntersect {
 //       //  compute plane equation of triangle: normal * x + d = 0
 //        Vector3f normal = new Vector3f();
 //        e0.cross(e1, normal);
-        Plane p = vars.plane;
+        Plane p = new Plane();
 
         p.setPlanePoints(v1,v2,v3);
         if (bbox.whichSide(p) == Plane.Side.Negative){
-            assert vars.unlock();
             return false;
         }
-//
-//        if(!planeBoxOverlap(normal,v0,boxhalfsize)) return false;
-
-        assert vars.unlock();
 
         return true;   /* box and triangle overlaps */
+    }
+
+    public static class BoundingBox
+    {
+        private final Vector3f center;
+        private final Vector3f extend;
+
+        public BoundingBox(Vector3f center, Vector3f extend) {
+            this.center = center;
+            this.extend = extend;
+        }
+
+        public final Vector3f getCenter() {
+            return center;
+        }
+
+        public Vector3f getExtent() {
+            return new Vector3f(extend);
+        }
+
+        public Plane.Side whichSide(Plane plane) {
+            float radius = Math.abs(extend.x * plane.getNormal().x)
+                + Math.abs(extend.y * plane.getNormal().y)
+                + Math.abs(extend.z * plane.getNormal().z);
+
+            float distance = plane.pseudoDistance(center);
+
+            //changed to < and > to prevent floating point precision problems
+            if (distance < -radius) {
+                return Plane.Side.Negative;
+            } else if (distance > radius) {
+                return Plane.Side.Positive;
+            } else {
+                return Plane.Side.None;
+            }
+        }
+    }
+
+    public static class Plane
+    {
+        public enum Side {
+            None,
+            Positive,
+            Negative
+        }
+
+        private Vector3f normal;
+        private float constant;
+
+
+        public void setPlanePoints(Vector3f v1, Vector3f v2, Vector3f v3) {
+            normal.set(v2).sub(v1);
+            normal.cross(v3.x - v1.x, v3.y - v1.y, v3.z - v1.z).normalize();
+            constant = normal.dot(v1);
+        }
+
+        public float pseudoDistance(Vector3f point) {
+            return normal.dot(point) - constant;
+        }
+
+        public Vector3f getNormal() {
+            return normal;
+        }
     }
 
 }

--- a/src/main/java/com/creativemd/littletiles/client/util3d/TriangleBoundingBoxIntersect.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/TriangleBoundingBoxIntersect.java
@@ -1,37 +1,31 @@
-package com.creativemd.littletiles.client.util3d;/*
-                                                  * Copyright (c) 2009-2010 jMonkeyEngine All rights reserved.
-                                                  * Redistribution and use in source and binary forms, with or without
-                                                  * modification, are permitted provided that the following conditions
-                                                  * are met: * Redistributions of source code must retain the above
-                                                  * copyright notice, this list of conditions and the following
-                                                  * disclaimer. * Redistributions in binary form must reproduce the
-                                                  * above copyright notice, this list of conditions and the following
-                                                  * disclaimer in the documentation and/or other materials provided with
-                                                  * the distribution. * Neither the name of 'jMonkeyEngine' nor the
-                                                  * names of its contributors may be used to endorse or promote products
-                                                  * derived from this software without specific prior written
-                                                  * permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-                                                  * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-                                                  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-                                                  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-                                                  * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-                                                  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-                                                  * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-                                                  * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-                                                  * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-                                                  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-                                                  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-                                                  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-                                                  */
+/*
+ * Copyright (c) 2009-2010 jMonkeyEngine All rights reserved. Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions are met: * Redistributions of source code
+ * must retain the above copyright notice, this list of conditions and the following disclaimer. * Redistributions in
+ * binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution. * Neither the name of 'jMonkeyEngine' nor the
+ * names of its contributors may be used to endorse or promote products derived from this software without specific
+ * prior written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.creativemd.littletiles.client.util3d;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 
 import org.joml.Vector3f;
 
+import com.creativemd.littletiles.common.utils.small.LittleTileBox;
+
 /**
  * This class includes some utility methods for computing intersection between bounding volumes and triangles.
- * 
+ *
  * @author Kirill
  */
 public class TriangleBoundingBoxIntersect {
@@ -42,6 +36,28 @@ public class TriangleBoundingBoxIntersect {
         if (f2 > minMax.y) minMax.y = f2;
         if (f3 < minMax.x) minMax.x = f3;
         if (f3 > minMax.y) minMax.y = f3;
+    }
+
+    public static boolean intersect(Mesh3d mesh, LittleTileBox box) {
+        Vector3f center = new Vector3f(
+                (box.maxX + box.minX) / 16f / 2,
+                (box.maxY + box.minY) / 16f / 2,
+                (box.maxZ + box.minZ) / 16f / 2);
+        Vector3f extend = new Vector3f(
+                (box.maxX - box.minX) / 16f / 2,
+                (box.maxY - box.minY) / 16f / 2,
+                (box.maxZ - box.minZ) / 16f / 2);
+        BoundingBox bb = new BoundingBox(center, extend);
+        for (Triangle3d triangle : mesh.getTriangles()) {
+            if (intersect(
+                    bb,
+                    triangle.getP1().toVector3f(),
+                    triangle.getP2().toVector3f(),
+                    triangle.getP3().toVector3f())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static boolean intersect(BoundingBox bbox, Vector3f v1, Vector3f v2, Vector3f v3) {
@@ -265,7 +281,7 @@ public class TriangleBoundingBoxIntersect {
             Negative
         }
 
-        private Vector3f normal;
+        private final Vector3f normal = new Vector3f();
         private float constant;
 
         public void setPlanePoints(Vector3f v1, Vector3f v2, Vector3f v3) {

--- a/src/main/java/com/creativemd/littletiles/client/util3d/TriangleBoundingBoxIntersect.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/TriangleBoundingBoxIntersect.java
@@ -1,0 +1,279 @@
+package com.creativemd.littletiles.client.util3d;/*
+ * Copyright (c) 2009-2010 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import com.jme3.util.TempVars;
+import com.jme3.math.FastMath;
+import com.jme3.math.Plane;
+import com.jme3.math.Vector3f;
+
+import static java.lang.Math.min;
+import static java.lang.Math.max;
+
+/**
+ * This class includes some utility methods for computing intersection
+ * between bounding volumes and triangles.
+ * @author Kirill
+ */
+public class TriangleBoundingBoxIntersect {
+
+    private static final void findMinMax(float x0, float x1, float x2, Vector3f minMax){
+        minMax.set(x0, x0, 0);
+        if (x1 < minMax.x) minMax.setX(x1);
+        if (x1 > minMax.y) minMax.setY(x1);
+        if (x2 < minMax.x) minMax.setX(x2);
+        if (x2 > minMax.y) minMax.setY(x2);
+    }
+
+//    private boolean axisTest(float a, float b, float fa, float fb, Vector3f v0, Vector3f v1, )
+
+//    private boolean axisTestX01(float a, float b, float fa, float fb,
+//                             Vector3f center, Vector3f ext,
+//                             Vector3f v1, Vector3f v2, Vector3f v3){
+//	float p0 = a * v0.y - b * v0.z;
+//	float p2 = a * v2.y - b * v2.z;
+//        if(p0 < p2){
+//            min = p0;
+//            max = p2;
+//        } else {
+//            min = p2;
+//            max = p0;
+//        }
+//	float rad = fa * boxhalfsize.y + fb * boxhalfsize.z;
+//	if(min > rad || max < -rad)
+//            return false;
+//    }
+
+    public static boolean intersect(BoundingBox bbox, Vector3f v1, Vector3f v2, Vector3f v3){
+        //  use separating axis theorem to test overlap between triangle and box
+        //  need to test for overlap in these directions:
+        //  1) the {x,y,z}-directions (actually, since we use the AABB of the triangle
+        //     we do not even need to test these)
+        //  2) normal of the triangle
+        //  3) crossproduct(edge from tri, {x,y,z}-directin)
+        //       this gives 3x3=9 more tests
+
+        TempVars vars = TempVars.get();
+        assert vars.lock();
+
+        Vector3f tmp0 = vars.vect1,
+            tmp1 = vars.vect2,
+            tmp2 = vars.vect3;
+
+        Vector3f e0 = vars.vect4,
+            e1 = vars.vect5,
+            e2 = vars.vect6;
+
+        Vector3f center = bbox.getCenter();
+        Vector3f extent = bbox.getExtent(null);
+
+//   float min,max,p0,p1,p2,rad,fex,fey,fez;
+//   float normal[3]
+
+        // This is the fastest branch on Sun
+        // move everything so that the boxcenter is in (0,0,0)
+        v1.subtract(center, tmp0);
+        v2.subtract(center, tmp1);
+        v3.subtract(center, tmp2);
+
+        // compute triangle edges
+        tmp1.subtract(tmp0, e0); // tri edge 0
+        tmp2.subtract(tmp1, e1); // tri edge 1
+        tmp0.subtract(tmp2, e2); // tri edge 2
+
+        // Bullet 3:
+        //  test the 9 tests first (this was faster)
+        float min, max;
+        float p0, p1, p2, rad;
+        float fex = FastMath.abs(e0.x);
+        float fey = FastMath.abs(e0.y);
+        float fez = FastMath.abs(e0.z);
+
+
+
+        //AXISTEST_X01(e0[Z], e0[Y], fez, fey);
+        p0 = e0.z * tmp0.y - e0.y * tmp0.z;
+        p2 = e0.z * tmp2.y - e0.y * tmp2.z;
+        min = min(p0,p2);
+        max = max(p0,p2);
+        rad = fez * extent.y + fey * extent.z;
+        if (min > rad || max < -rad){
+            assert vars.unlock();
+            return false;
+        }
+
+        //   AXISTEST_Y02(e0[Z], e0[X], fez, fex);
+        p0 = -e0.z * tmp0.x + e0.x * tmp0.z;
+        p2 = -e0.z * tmp2.x + e0.x * tmp2.z;
+        min = min(p0,p2);
+        max = max(p0,p2);
+        rad = fez * extent.x + fex * extent.z;
+        if (min > rad || max < -rad){
+            assert vars.unlock();
+            return false;
+        }
+
+        // AXISTEST_Z12(e0[Y], e0[X], fey, fex);
+        p1 = e0.y * tmp1.x - e0.x * tmp1.y;
+        p2 = e0.y * tmp2.x - e0.x * tmp2.y;
+        min = min(p1,p2);
+        max = max(p1,p2);
+        rad = fey * extent.x + fex * extent.y;
+        if (min > rad || max < -rad){
+            assert vars.unlock();
+            return false;
+        }
+
+        fex = FastMath.abs(e1.x);
+        fey = FastMath.abs(e1.y);
+        fez = FastMath.abs(e1.z);
+
+//        AXISTEST_X01(e1[Z], e1[Y], fez, fey);
+        p0 = e1.z * tmp0.y - e1.y * tmp0.z;
+        p2 = e1.z * tmp2.y - e1.y * tmp2.z;
+        min = min(p0,p2);
+        max = max(p0,p2);
+        rad = fez * extent.y + fey * extent.z;
+        if (min > rad || max < -rad){
+            assert vars.unlock();
+            return false;
+        }
+
+        //   AXISTEST_Y02(e1[Z], e1[X], fez, fex);
+        p0 = -e1.z * tmp0.x + e1.x * tmp0.z;
+        p2 = -e1.z * tmp2.x + e1.x * tmp2.z;
+        min = min(p0,p2);
+        max = max(p0,p2);
+        rad = fez * extent.x + fex * extent.z;
+        if (min > rad || max < -rad){
+            assert vars.unlock();
+            return false;
+        }
+
+        // AXISTEST_Z0(e1[Y], e1[X], fey, fex);
+        p0 = e1.y * tmp0.x - e1.x * tmp0.y;
+        p1 = e1.y * tmp1.x - e1.x * tmp1.y;
+        min = min(p0,p1);
+        max = max(p0,p1);
+        rad = fey * extent.x + fex * extent.y;
+        if (min > rad || max < -rad){
+            assert vars.unlock();
+            return false;
+        }
+//
+        fex = FastMath.abs(e2.x);
+        fey = FastMath.abs(e2.y);
+        fez = FastMath.abs(e2.z);
+
+        // AXISTEST_X2(e2[Z], e2[Y], fez, fey);
+        p0 = e2.z * tmp0.y - e2.y * tmp0.z;
+        p1 = e2.z * tmp1.y - e2.y * tmp1.z;
+        min = min(p0,p1);
+        max = max(p0,p1);
+        rad = fez * extent.y + fey * extent.z;
+        if (min > rad || max < -rad){
+            assert vars.unlock();
+            return false;
+        }
+
+        // AXISTEST_Y1(e2[Z], e2[X], fez, fex);
+        p0 = -e2.z * tmp0.x + e2.x * tmp0.z;
+        p1 = -e2.z * tmp1.x + e2.x * tmp1.z;
+        min = min(p0,p1);
+        max = max(p0,p1);
+        rad = fez * extent.x + fex * extent.y;
+        if (min > rad || max < -rad){
+            assert vars.unlock();
+            return false;
+        }
+
+//   AXISTEST_Z12(e2[Y], e2[X], fey, fex);
+        p1 = e2.y * tmp1.x - e2.x * tmp1.y;
+        p2 = e2.y * tmp2.x - e2.x * tmp2.y;
+        min = min(p1,p2);
+        max = max(p1,p2);
+        rad = fey * extent.x + fex * extent.y;
+        if (min > rad || max < -rad){
+            assert vars.unlock();
+            return false;
+        }
+
+        //  Bullet 1:
+        //  first test overlap in the {x,y,z}-directions
+        //  find min, max of the triangle each direction, and test for overlap in
+        //  that direction -- this is equivalent to testing a minimal AABB around
+        //  the triangle against the AABB
+
+
+        Vector3f minMax = vars.vect7;
+
+        // test in X-direction
+        findMinMax(tmp0.x, tmp1.x, tmp2.x, minMax);
+        if(minMax.x > extent.x || minMax.y < -extent.x){
+            assert vars.unlock();
+            return false;
+        }
+
+        // test in Y-direction
+        findMinMax(tmp0.y, tmp1.y, tmp2.y, minMax);
+        if(minMax.x > extent.y || minMax.y < -extent.y){
+            assert vars.unlock();
+            return false;
+        }
+
+        // test in Z-direction
+        findMinMax(tmp0.z, tmp1.z, tmp2.z, minMax);
+        if(minMax.x > extent.z || minMax.y < -extent.z){
+            assert vars.unlock();
+            return false;
+        }
+
+//       // Bullet 2:
+//       //  test if the box intersects the plane of the triangle
+//       //  compute plane equation of triangle: normal * x + d = 0
+//        Vector3f normal = new Vector3f();
+//        e0.cross(e1, normal);
+        Plane p = vars.plane;
+
+        p.setPlanePoints(v1,v2,v3);
+        if (bbox.whichSide(p) == Plane.Side.Negative){
+            assert vars.unlock();
+            return false;
+        }
+//
+//        if(!planeBoxOverlap(normal,v0,boxhalfsize)) return false;
+
+        assert vars.unlock();
+
+        return true;   /* box and triangle overlaps */
+    }
+
+}

--- a/src/main/java/com/creativemd/littletiles/client/util3d/TriangleIntersect.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/TriangleIntersect.java
@@ -1,33 +1,17 @@
 /*
- * Copyright (c) 2003-2009 jMonkeyEngine
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are
- * met:
- *
- * * Redistributions of source code must retain the above copyright
- *   notice, this list of conditions and the following disclaimer.
- *
- * * Redistributions in binary form must reproduce the above copyright
- *   notice, this list of conditions and the following disclaimer in the
- *   documentation and/or other materials provided with the distribution.
- *
- * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
- *   may be used to endorse or promote products derived from this software
- *   without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
- * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
- * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright (c) 2003-2009 jMonkeyEngine All rights reserved. Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions are met: * Redistributions of source code
+ * must retain the above copyright notice, this list of conditions and the following disclaimer. * Redistributions in
+ * binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution. * Neither the name of 'jMonkeyEngine' nor the
+ * names of its contributors may be used to endorse or promote products derived from this software without specific
+ * prior written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 package com.jme.intersection;
@@ -42,12 +26,10 @@ import com.jme.scene.TriMesh;
 import com.jme.util.geom.BufferUtils;
 
 /**
- * <code>Intersection</code> provides functional methods for calculating the
- * intersection of some objects. All the methods are static to allow for quick
- * and easy calls. <code>Intersection</code> relays requests to specific
- * classes to handle the actual work. By providing checks to just
- * <code>BoundingVolume</code> the client application need not worry about
- * what type of bounding volume is being used.
+ * <code>Intersection</code> provides functional methods for calculating the intersection of some objects. All the
+ * methods are static to allow for quick and easy calls. <code>Intersection</code> relays requests to specific classes
+ * to handle the actual work. By providing checks to just <code>BoundingVolume</code> the client application need not
+ * worry about what type of bounding volume is being used.
  *
  * @author Mark Powell
  * @version $Id: Intersection.java 4131 2009-03-19 20:15:28Z blaine.dev $
@@ -78,13 +60,10 @@ public class Intersection {
     private static final Vector2f tempV2b = new Vector2f();
 
     /**
-     * This is a <b>VERY </b> brute force method of detecting if two TriMesh
-     * objects intersect.
+     * This is a <b>VERY </b> brute force method of detecting if two TriMesh objects intersect.
      *
-     * @param mesh1
-     *            The first TriMesh.
-     * @param mesh2
-     *            The second TriMesh.
+     * @param mesh1 The first TriMesh.
+     * @param mesh2 The second TriMesh.
      * @return True if they intersect, false otherwise.
      */
     public static boolean meshIntersection(TriMesh mesh1, TriMesh mesh2) {
@@ -102,19 +81,20 @@ public class Intersection {
         bTransform.setScale(mesh2.getWorldScale());
 
         Vector3f[] vertA = BufferUtils.getVector3Array(mesh1.getVertexBuffer());
-        for (int i = 0; i < vertA.length; i++)
-            aTransform.multPoint(vertA[i]);
+        for (int i = 0; i < vertA.length; i++) aTransform.multPoint(vertA[i]);
 
         Vector3f[] vertB = BufferUtils.getVector3Array(mesh2.getVertexBuffer());
-        for (int i = 0; i < vertB.length; i++)
-            bTransform.multPoint(vertB[i]);
+        for (int i = 0; i < vertB.length; i++) bTransform.multPoint(vertB[i]);
 
         for (int i = 0; i < mesh1.getTriangleCount(); i++) {
             for (int j = 0; j < mesh2.getTriangleCount(); j++) {
-                if (intersection(vertA[indexA.get(i * 3 + 0)],
-                    vertA[indexA.get(i * 3 + 1)], vertA[indexA.get(i * 3 + 2)],
-                    vertB[indexB.get(j * 3 + 0)], vertB[indexB.get(j * 3 + 1)],
-                    vertB[indexB.get(j * 3 + 2)]))
+                if (intersection(
+                        vertA[indexA.get(i * 3 + 0)],
+                        vertA[indexA.get(i * 3 + 1)],
+                        vertA[indexA.get(i * 3 + 2)],
+                        vertB[indexB.get(j * 3 + 0)],
+                        vertB[indexB.get(j * 3 + 1)],
+                        vertB[indexB.get(j * 3 + 2)]))
                     return true;
             }
         }
@@ -122,26 +102,18 @@ public class Intersection {
     }
 
     /**
-     * This method tests for the intersection between two triangles defined by
-     * their vertexes. Converted to java from C code found at
-     * http://www.acm.org/jgt/papers/Moller97/tritri.html
+     * This method tests for the intersection between two triangles defined by their vertexes. Converted to java from C
+     * code found at http://www.acm.org/jgt/papers/Moller97/tritri.html
      *
-     * @param v0
-     *            First triangle's first vertex.
-     * @param v1
-     *            First triangle's second vertex.
-     * @param v2
-     *            First triangle's third vertex.
-     * @param u0
-     *            Second triangle's first vertex.
-     * @param u1
-     *            Second triangle's second vertex.
-     * @param u2
-     *            Second triangle's third vertex.
+     * @param v0 First triangle's first vertex.
+     * @param v1 First triangle's second vertex.
+     * @param v2 First triangle's third vertex.
+     * @param u0 Second triangle's first vertex.
+     * @param u1 Second triangle's second vertex.
+     * @param u2 Second triangle's third vertex.
      * @return True if the two triangles intersect, false otherwise.
      */
-    public static boolean intersection(Vector3f v0, Vector3f v1, Vector3f v2,
-                                       Vector3f u0, Vector3f u1, Vector3f u2) {
+    public static boolean intersection(Vector3f v0, Vector3f v1, Vector3f v2, Vector3f u0, Vector3f u1, Vector3f u2) {
         Vector3f e1 = tempVa;
         Vector3f e2 = tempVb;
         Vector3f n1 = tempVc;
@@ -166,20 +138,16 @@ public class Intersection {
         /* plane equation 1: n1.X+d1=0 */
 
         /*
-         * put u0,u1,u2 into plane equation 1 to compute signed distances to the
-         * plane
+         * put u0,u1,u2 into plane equation 1 to compute signed distances to the plane
          */
         du0 = n1.dot(u0) + d1;
         du1 = n1.dot(u1) + d1;
         du2 = n1.dot(u2) + d1;
 
         /* coplanarity robustness check */
-        if (FastMath.abs(du0) < EPSILON)
-            du0 = 0.0f;
-        if (FastMath.abs(du1) < EPSILON)
-            du1 = 0.0f;
-        if (FastMath.abs(du2) < EPSILON)
-            du2 = 0.0f;
+        if (FastMath.abs(du0) < EPSILON) du0 = 0.0f;
+        if (FastMath.abs(du1) < EPSILON) du1 = 0.0f;
+        if (FastMath.abs(du2) < EPSILON) du2 = 0.0f;
         du0du1 = du0 * du1;
         du0du2 = du0 * du2;
 
@@ -199,20 +167,16 @@ public class Intersection {
         dv1 = n2.dot(v1) + d2;
         dv2 = n2.dot(v2) + d2;
 
-        if (FastMath.abs(dv0) < EPSILON)
-            dv0 = 0.0f;
-        if (FastMath.abs(dv1) < EPSILON)
-            dv1 = 0.0f;
-        if (FastMath.abs(dv2) < EPSILON)
-            dv2 = 0.0f;
+        if (FastMath.abs(dv0) < EPSILON) dv0 = 0.0f;
+        if (FastMath.abs(dv1) < EPSILON) dv1 = 0.0f;
+        if (FastMath.abs(dv2) < EPSILON) dv2 = 0.0f;
 
         dv0dv1 = dv0 * dv1;
         dv0dv2 = dv0 * dv2;
 
         if (dv0dv1 > 0.0f && dv0dv2 > 0.0f) { /*
-         * same sign on all of them + not
-         * equal 0 ?
-         */
+                                               * same sign on all of them + not equal 0 ?
+                                               */
             return false; /* no intersection occurs */
         }
 
@@ -259,16 +223,14 @@ public class Intersection {
         /* compute interval for triangle 1 */
         Vector3f abc = tempVa;
         Vector2f x0x1 = tempV2a;
-        if (newComputeIntervals(vp0, vp1, vp2, dv0, dv1, dv2, dv0dv1, dv0dv2,
-            abc, x0x1)) {
+        if (newComputeIntervals(vp0, vp1, vp2, dv0, dv1, dv2, dv0dv1, dv0dv2, abc, x0x1)) {
             return coplanarTriTri(n1, v0, v1, v2, u0, u1, u2);
         }
 
         /* compute interval for triangle 2 */
         Vector3f def = tempVb;
         Vector2f y0y1 = tempV2b;
-        if (newComputeIntervals(up0, up1, up2, du0, du1, du2, du0du1, du0du2,
-            def, y0y1)) {
+        if (newComputeIntervals(up0, up1, up2, du0, du1, du2, du0du1, du0du2, def, y0y1)) {
             return coplanarTriTri(n1, v0, v1, v2, u0, u1, u2);
         }
 
@@ -302,14 +264,12 @@ public class Intersection {
         }
     }
 
-    private static boolean newComputeIntervals(float vv0, float vv1, float vv2,
-                                               float d0, float d1, float d2, float d0d1, float d0d2, Vector3f abc,
-                                               Vector2f x0x1) {
+    private static boolean newComputeIntervals(float vv0, float vv1, float vv2, float d0, float d1, float d2,
+            float d0d1, float d0d2, Vector3f abc, Vector2f x0x1) {
         if (d0d1 > 0.0f) {
             /* here we know that d0d2 <=0.0 */
             /*
-             * that is d0, d1 are on the same side, d2 on the other or on the
-             * plane
+             * that is d0, d1 are on the same side, d2 on the other or on the plane
              */
             abc.x = vv2;
             abc.y = (vv0 - vv2) * d2;
@@ -349,8 +309,8 @@ public class Intersection {
         return false;
     }
 
-    private static boolean coplanarTriTri(Vector3f n, Vector3f v0, Vector3f v1,
-                                          Vector3f v2, Vector3f u0, Vector3f u1, Vector3f u2) {
+    private static boolean coplanarTriTri(Vector3f n, Vector3f v0, Vector3f v1, Vector3f v2, Vector3f u0, Vector3f u1,
+            Vector3f u2) {
         Vector3f a = new Vector3f();
         short i0, i1;
         a.x = FastMath.abs(n.x);
@@ -365,7 +325,7 @@ public class Intersection {
                 i0 = 0; /* a[2] is greatest */
                 i1 = 1;
             }
-        } else /* a[0] <=a[1] */{
+        } else /* a[0] <=a[1] */ {
             if (a.z > a.y) {
                 i0 = 0; /* a[2] is greatest */
                 i1 = 1;
@@ -407,8 +367,7 @@ public class Intersection {
         return false;
     }
 
-    private static boolean pointInTri(float[] V0, float[] U0, float[] U1,
-                                      float[] U2, int i0, int i1) {
+    private static boolean pointInTri(float[] V0, float[] U0, float[] U1, float[] U2, int i0, int i1) {
         float a, b, c, d0, d1, d2;
         /* is T1 completly inside T2? */
         /* check if V0 is inside tri(U0,U1,U2) */
@@ -426,14 +385,13 @@ public class Intersection {
         b = -(U0[i0] - U2[i0]);
         c = -a * U2[i0] - b * U2[i1];
         d2 = a * V0[i0] + b * V0[i1] + c;
-        if (d0 * d1 > 0.0 && d0 * d2 > 0.0)
-            return true;
+        if (d0 * d1 > 0.0 && d0 * d2 > 0.0) return true;
 
         return false;
     }
 
-    private static boolean edgeAgainstTriEdges(float[] v0, float[] v1,
-                                               float[] u0, float[] u1, float[] u2, int i0, int i1) {
+    private static boolean edgeAgainstTriEdges(float[] v0, float[] v1, float[] u0, float[] u1, float[] u2, int i0,
+            int i1) {
         float aX, aY;
         aX = v1[i0] - v0[i0];
         aY = v1[i1] - v0[i1];
@@ -452,8 +410,7 @@ public class Intersection {
         return false;
     }
 
-    private static boolean edgeEdgeTest(float[] v0, float[] u0, float[] u1,
-                                        int i0, int i1, float aX, float Ay) {
+    private static boolean edgeEdgeTest(float[] v0, float[] u0, float[] u1, int i0, int i1, float aX, float Ay) {
         float Bx = u0[i0] - u1[i0];
         float By = u0[i1] - u1[i1];
         float Cx = v0[i0] - u0[i0];
@@ -463,11 +420,9 @@ public class Intersection {
         if ((f > 0 && d >= 0 && d <= f) || (f < 0 && d <= 0 && d >= f)) {
             float e = aX * Cy - Ay * Cx;
             if (f > 0) {
-                if (e >= 0 && e <= f)
-                    return true;
+                if (e >= 0 && e <= f) return true;
             } else {
-                if (e <= 0 && e >= f)
-                    return true;
+                if (e <= 0 && e >= f) return true;
             }
         }
         return false;

--- a/src/main/java/com/creativemd/littletiles/client/util3d/TriangleIntersect.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/TriangleIntersect.java
@@ -14,27 +14,12 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.jme.intersection;
+package com.creativemd.littletiles.client.util3d;
 
-import java.nio.IntBuffer;
+import org.joml.Vector2f;
+import org.joml.Vector3f;
 
-import com.jme.math.FastMath;
-import com.jme.math.TransformMatrix;
-import com.jme.math.Vector2f;
-import com.jme.math.Vector3f;
-import com.jme.scene.TriMesh;
-import com.jme.util.geom.BufferUtils;
-
-/**
- * <code>Intersection</code> provides functional methods for calculating the intersection of some objects. All the
- * methods are static to allow for quick and easy calls. <code>Intersection</code> relays requests to specific classes
- * to handle the actual work. By providing checks to just <code>BoundingVolume</code> the client application need not
- * worry about what type of bounding volume is being used.
- *
- * @author Mark Powell
- * @version $Id: Intersection.java 4131 2009-03-19 20:15:28Z blaine.dev $
- */
-public class Intersection {
+public class TriangleIntersect {
 
     /**
      * EPSILON represents the error buffer used to denote a hit.
@@ -66,35 +51,19 @@ public class Intersection {
      * @param mesh2 The second TriMesh.
      * @return True if they intersect, false otherwise.
      */
-    public static boolean meshIntersection(TriMesh mesh1, TriMesh mesh2) {
+    public static boolean meshIntersection(Mesh3d mesh1, Mesh3d mesh2) {
+        Vector3f[] vertA = mesh1.getVertices();
+        Vector3f[] vertB = mesh2.getVertices();
 
-        IntBuffer indexA = mesh1.getIndexBuffer();
-        IntBuffer indexB = mesh2.getIndexBuffer();
-        TransformMatrix aTransform = new TransformMatrix();
-        aTransform.setRotationQuaternion(mesh1.getWorldRotation());
-        aTransform.setTranslation(mesh1.getWorldTranslation());
-        aTransform.setScale(mesh1.getWorldScale());
-
-        TransformMatrix bTransform = new TransformMatrix();
-        bTransform.setRotationQuaternion(mesh2.getWorldRotation());
-        bTransform.setTranslation(mesh2.getWorldTranslation());
-        bTransform.setScale(mesh2.getWorldScale());
-
-        Vector3f[] vertA = BufferUtils.getVector3Array(mesh1.getVertexBuffer());
-        for (int i = 0; i < vertA.length; i++) aTransform.multPoint(vertA[i]);
-
-        Vector3f[] vertB = BufferUtils.getVector3Array(mesh2.getVertexBuffer());
-        for (int i = 0; i < vertB.length; i++) bTransform.multPoint(vertB[i]);
-
-        for (int i = 0; i < mesh1.getTriangleCount(); i++) {
-            for (int j = 0; j < mesh2.getTriangleCount(); j++) {
+        for (int i = 0; i < mesh1.getTriangles().size(); i++) {
+            for (int j = 0; j < mesh2.getTriangles().size(); j++) {
                 if (intersection(
-                        vertA[indexA.get(i * 3 + 0)],
-                        vertA[indexA.get(i * 3 + 1)],
-                        vertA[indexA.get(i * 3 + 2)],
-                        vertB[indexB.get(j * 3 + 0)],
-                        vertB[indexB.get(j * 3 + 1)],
-                        vertB[indexB.get(j * 3 + 2)]))
+                        vertA[i * 3],
+                        vertA[i * 3 + 1],
+                        vertA[i * 3 + 2],
+                        vertB[j * 3],
+                        vertB[j * 3 + 1],
+                        vertB[j * 3 + 2]))
                     return true;
             }
         }
@@ -131,8 +100,8 @@ public class Intersection {
         float xx, yy, xxyy, tmp;
 
         /* compute plane equation of triangle(v0,v1,v2) */
-        v1.subtract(v0, e1);
-        v2.subtract(v0, e2);
+        v1.sub(v0, e1);
+        v2.sub(v0, e2);
         e1.cross(e2, n1);
         d1 = -n1.dot(v0);
         /* plane equation 1: n1.X+d1=0 */
@@ -145,9 +114,9 @@ public class Intersection {
         du2 = n1.dot(u2) + d1;
 
         /* coplanarity robustness check */
-        if (FastMath.abs(du0) < EPSILON) du0 = 0.0f;
-        if (FastMath.abs(du1) < EPSILON) du1 = 0.0f;
-        if (FastMath.abs(du2) < EPSILON) du2 = 0.0f;
+        if (Math.abs(du0) < EPSILON) du0 = 0.0f;
+        if (Math.abs(du1) < EPSILON) du1 = 0.0f;
+        if (Math.abs(du2) < EPSILON) du2 = 0.0f;
         du0du1 = du0 * du1;
         du0du2 = du0 * du2;
 
@@ -156,8 +125,8 @@ public class Intersection {
         }
 
         /* compute plane of triangle (u0,u1,u2) */
-        u1.subtract(u0, e1);
-        u2.subtract(u0, e2);
+        u1.sub(u0, e1);
+        u2.sub(u0, e2);
         e1.cross(e2, n2);
         d2 = -n2.dot(u0);
         /* plane equation 2: n2.X+d2=0 */
@@ -167,9 +136,9 @@ public class Intersection {
         dv1 = n2.dot(v1) + d2;
         dv2 = n2.dot(v2) + d2;
 
-        if (FastMath.abs(dv0) < EPSILON) dv0 = 0.0f;
-        if (FastMath.abs(dv1) < EPSILON) dv1 = 0.0f;
-        if (FastMath.abs(dv2) < EPSILON) dv2 = 0.0f;
+        if (Math.abs(dv0) < EPSILON) dv0 = 0.0f;
+        if (Math.abs(dv1) < EPSILON) dv1 = 0.0f;
+        if (Math.abs(dv2) < EPSILON) dv2 = 0.0f;
 
         dv0dv1 = dv0 * dv1;
         dv0dv2 = dv0 * dv2;
@@ -184,10 +153,10 @@ public class Intersection {
         n1.cross(n2, d);
 
         /* compute and index to the largest component of d */
-        max = FastMath.abs(d.x);
+        max = Math.abs(d.x);
         index = 0;
-        bb = FastMath.abs(d.y);
-        cc = FastMath.abs(d.z);
+        bb = Math.abs(d.y);
+        cc = Math.abs(d.z);
         if (bb > max) {
             max = bb;
             index = 1;
@@ -313,9 +282,9 @@ public class Intersection {
             Vector3f u2) {
         Vector3f a = new Vector3f();
         short i0, i1;
-        a.x = FastMath.abs(n.x);
-        a.y = FastMath.abs(n.y);
-        a.z = FastMath.abs(n.z);
+        a.x = Math.abs(n.x);
+        a.y = Math.abs(n.y);
+        a.z = Math.abs(n.z);
 
         if (a.x > a.y) {
             if (a.x > a.z) {
@@ -337,17 +306,17 @@ public class Intersection {
 
         /* test all edges of triangle 1 against the edges of triangle 2 */
         float[] v0f = new float[3];
-        v0.toArray(v0f);
+        toArray(v0, v0f);
         float[] v1f = new float[3];
-        v1.toArray(v1f);
+        toArray(v1, v1f);
         float[] v2f = new float[3];
-        v2.toArray(v2f);
+        toArray(v2, v2f);
         float[] u0f = new float[3];
-        u0.toArray(u0f);
+        toArray(u0, u0f);
         float[] u1f = new float[3];
-        u1.toArray(u1f);
+        toArray(u1, u1f);
         float[] u2f = new float[3];
-        u2.toArray(u2f);
+        toArray(u2, u2f);
         if (edgeAgainstTriEdges(v0f, v1f, u0f, u1f, u2f, i0, i1)) {
             return true;
         }
@@ -426,5 +395,11 @@ public class Intersection {
             }
         }
         return false;
+    }
+
+    static void toArray(Vector3f vec, float[] arr) {
+        arr[0] = vec.x;
+        arr[1] = vec.y;
+        arr[2] = vec.z;
     }
 }

--- a/src/main/java/com/creativemd/littletiles/client/util3d/TriangleIntersect.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/TriangleIntersect.java
@@ -1,0 +1,475 @@
+/*
+ * Copyright (c) 2003-2009 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.jme.intersection;
+
+import java.nio.IntBuffer;
+
+import com.jme.math.FastMath;
+import com.jme.math.TransformMatrix;
+import com.jme.math.Vector2f;
+import com.jme.math.Vector3f;
+import com.jme.scene.TriMesh;
+import com.jme.util.geom.BufferUtils;
+
+/**
+ * <code>Intersection</code> provides functional methods for calculating the
+ * intersection of some objects. All the methods are static to allow for quick
+ * and easy calls. <code>Intersection</code> relays requests to specific
+ * classes to handle the actual work. By providing checks to just
+ * <code>BoundingVolume</code> the client application need not worry about
+ * what type of bounding volume is being used.
+ *
+ * @author Mark Powell
+ * @version $Id: Intersection.java 4131 2009-03-19 20:15:28Z blaine.dev $
+ */
+public class Intersection {
+
+    /**
+     * EPSILON represents the error buffer used to denote a hit.
+     */
+    public static final double EPSILON = 1e-12;
+
+    private static final Vector3f tempVa = new Vector3f();
+
+    private static final Vector3f tempVb = new Vector3f();
+
+    private static final Vector3f tempVc = new Vector3f();
+
+    private static final Vector3f tempVd = new Vector3f();
+
+    private static final Vector3f tempVe = new Vector3f();
+
+    private static final float[] tempFa = new float[2];
+
+    private static final float[] tempFb = new float[2];
+
+    private static final Vector2f tempV2a = new Vector2f();
+
+    private static final Vector2f tempV2b = new Vector2f();
+
+    /**
+     * This is a <b>VERY </b> brute force method of detecting if two TriMesh
+     * objects intersect.
+     *
+     * @param mesh1
+     *            The first TriMesh.
+     * @param mesh2
+     *            The second TriMesh.
+     * @return True if they intersect, false otherwise.
+     */
+    public static boolean meshIntersection(TriMesh mesh1, TriMesh mesh2) {
+
+        IntBuffer indexA = mesh1.getIndexBuffer();
+        IntBuffer indexB = mesh2.getIndexBuffer();
+        TransformMatrix aTransform = new TransformMatrix();
+        aTransform.setRotationQuaternion(mesh1.getWorldRotation());
+        aTransform.setTranslation(mesh1.getWorldTranslation());
+        aTransform.setScale(mesh1.getWorldScale());
+
+        TransformMatrix bTransform = new TransformMatrix();
+        bTransform.setRotationQuaternion(mesh2.getWorldRotation());
+        bTransform.setTranslation(mesh2.getWorldTranslation());
+        bTransform.setScale(mesh2.getWorldScale());
+
+        Vector3f[] vertA = BufferUtils.getVector3Array(mesh1.getVertexBuffer());
+        for (int i = 0; i < vertA.length; i++)
+            aTransform.multPoint(vertA[i]);
+
+        Vector3f[] vertB = BufferUtils.getVector3Array(mesh2.getVertexBuffer());
+        for (int i = 0; i < vertB.length; i++)
+            bTransform.multPoint(vertB[i]);
+
+        for (int i = 0; i < mesh1.getTriangleCount(); i++) {
+            for (int j = 0; j < mesh2.getTriangleCount(); j++) {
+                if (intersection(vertA[indexA.get(i * 3 + 0)],
+                    vertA[indexA.get(i * 3 + 1)], vertA[indexA.get(i * 3 + 2)],
+                    vertB[indexB.get(j * 3 + 0)], vertB[indexB.get(j * 3 + 1)],
+                    vertB[indexB.get(j * 3 + 2)]))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * This method tests for the intersection between two triangles defined by
+     * their vertexes. Converted to java from C code found at
+     * http://www.acm.org/jgt/papers/Moller97/tritri.html
+     *
+     * @param v0
+     *            First triangle's first vertex.
+     * @param v1
+     *            First triangle's second vertex.
+     * @param v2
+     *            First triangle's third vertex.
+     * @param u0
+     *            Second triangle's first vertex.
+     * @param u1
+     *            Second triangle's second vertex.
+     * @param u2
+     *            Second triangle's third vertex.
+     * @return True if the two triangles intersect, false otherwise.
+     */
+    public static boolean intersection(Vector3f v0, Vector3f v1, Vector3f v2,
+                                       Vector3f u0, Vector3f u1, Vector3f u2) {
+        Vector3f e1 = tempVa;
+        Vector3f e2 = tempVb;
+        Vector3f n1 = tempVc;
+        Vector3f n2 = tempVd;
+        float d1, d2;
+        float du0, du1, du2, dv0, dv1, dv2;
+        Vector3f d = tempVe;
+        float[] isect1 = tempFa;
+        float[] isect2 = tempFb;
+        float du0du1, du0du2, dv0dv1, dv0dv2;
+        short index;
+        float vp0, vp1, vp2;
+        float up0, up1, up2;
+        float bb, cc, max;
+        float xx, yy, xxyy, tmp;
+
+        /* compute plane equation of triangle(v0,v1,v2) */
+        v1.subtract(v0, e1);
+        v2.subtract(v0, e2);
+        e1.cross(e2, n1);
+        d1 = -n1.dot(v0);
+        /* plane equation 1: n1.X+d1=0 */
+
+        /*
+         * put u0,u1,u2 into plane equation 1 to compute signed distances to the
+         * plane
+         */
+        du0 = n1.dot(u0) + d1;
+        du1 = n1.dot(u1) + d1;
+        du2 = n1.dot(u2) + d1;
+
+        /* coplanarity robustness check */
+        if (FastMath.abs(du0) < EPSILON)
+            du0 = 0.0f;
+        if (FastMath.abs(du1) < EPSILON)
+            du1 = 0.0f;
+        if (FastMath.abs(du2) < EPSILON)
+            du2 = 0.0f;
+        du0du1 = du0 * du1;
+        du0du2 = du0 * du2;
+
+        if (du0du1 > 0.0f && du0du2 > 0.0f) {
+            return false;
+        }
+
+        /* compute plane of triangle (u0,u1,u2) */
+        u1.subtract(u0, e1);
+        u2.subtract(u0, e2);
+        e1.cross(e2, n2);
+        d2 = -n2.dot(u0);
+        /* plane equation 2: n2.X+d2=0 */
+
+        /* put v0,v1,v2 into plane equation 2 */
+        dv0 = n2.dot(v0) + d2;
+        dv1 = n2.dot(v1) + d2;
+        dv2 = n2.dot(v2) + d2;
+
+        if (FastMath.abs(dv0) < EPSILON)
+            dv0 = 0.0f;
+        if (FastMath.abs(dv1) < EPSILON)
+            dv1 = 0.0f;
+        if (FastMath.abs(dv2) < EPSILON)
+            dv2 = 0.0f;
+
+        dv0dv1 = dv0 * dv1;
+        dv0dv2 = dv0 * dv2;
+
+        if (dv0dv1 > 0.0f && dv0dv2 > 0.0f) { /*
+         * same sign on all of them + not
+         * equal 0 ?
+         */
+            return false; /* no intersection occurs */
+        }
+
+        /* compute direction of intersection line */
+        n1.cross(n2, d);
+
+        /* compute and index to the largest component of d */
+        max = FastMath.abs(d.x);
+        index = 0;
+        bb = FastMath.abs(d.y);
+        cc = FastMath.abs(d.z);
+        if (bb > max) {
+            max = bb;
+            index = 1;
+        }
+        if (cc > max) {
+            max = cc;
+            vp0 = v0.z;
+            vp1 = v1.z;
+            vp2 = v2.z;
+
+            up0 = u0.z;
+            up1 = u1.z;
+            up2 = u2.z;
+
+        } else if (index == 1) {
+            vp0 = v0.y;
+            vp1 = v1.y;
+            vp2 = v2.y;
+
+            up0 = u0.y;
+            up1 = u1.y;
+            up2 = u2.y;
+        } else {
+            vp0 = v0.x;
+            vp1 = v1.x;
+            vp2 = v2.x;
+
+            up0 = u0.x;
+            up1 = u1.x;
+            up2 = u2.x;
+        }
+
+        /* compute interval for triangle 1 */
+        Vector3f abc = tempVa;
+        Vector2f x0x1 = tempV2a;
+        if (newComputeIntervals(vp0, vp1, vp2, dv0, dv1, dv2, dv0dv1, dv0dv2,
+            abc, x0x1)) {
+            return coplanarTriTri(n1, v0, v1, v2, u0, u1, u2);
+        }
+
+        /* compute interval for triangle 2 */
+        Vector3f def = tempVb;
+        Vector2f y0y1 = tempV2b;
+        if (newComputeIntervals(up0, up1, up2, du0, du1, du2, du0du1, du0du2,
+            def, y0y1)) {
+            return coplanarTriTri(n1, v0, v1, v2, u0, u1, u2);
+        }
+
+        xx = x0x1.x * x0x1.y;
+        yy = y0y1.x * y0y1.y;
+        xxyy = xx * yy;
+
+        tmp = abc.x * xxyy;
+        isect1[0] = tmp + abc.y * x0x1.y * yy;
+        isect1[1] = tmp + abc.z * x0x1.x * yy;
+
+        tmp = def.x * xxyy;
+        isect2[0] = tmp + def.y * xx * y0y1.y;
+        isect2[1] = tmp + def.z * xx * y0y1.x;
+
+        sort(isect1);
+        sort(isect2);
+
+        if (isect1[1] < isect2[0] || isect2[1] < isect1[0]) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void sort(float[] f) {
+        if (f[0] > f[1]) {
+            float c = f[0];
+            f[0] = f[1];
+            f[1] = c;
+        }
+    }
+
+    private static boolean newComputeIntervals(float vv0, float vv1, float vv2,
+                                               float d0, float d1, float d2, float d0d1, float d0d2, Vector3f abc,
+                                               Vector2f x0x1) {
+        if (d0d1 > 0.0f) {
+            /* here we know that d0d2 <=0.0 */
+            /*
+             * that is d0, d1 are on the same side, d2 on the other or on the
+             * plane
+             */
+            abc.x = vv2;
+            abc.y = (vv0 - vv2) * d2;
+            abc.z = (vv1 - vv2) * d2;
+            x0x1.x = d2 - d0;
+            x0x1.y = d2 - d1;
+        } else if (d0d2 > 0.0f) {
+            /* here we know that d0d1 <=0.0 */
+            abc.x = vv1;
+            abc.y = (vv0 - vv1) * d1;
+            abc.z = (vv2 - vv1) * d1;
+            x0x1.x = d1 - d0;
+            x0x1.y = d1 - d2;
+        } else if (d1 * d2 > 0.0f || d0 != 0.0f) {
+            /* here we know that d0d1 <=0.0 or that d0!=0.0 */
+            abc.x = vv0;
+            abc.y = (vv1 - vv0) * d0;
+            abc.z = (vv2 - vv0) * d0;
+            x0x1.x = d0 - d1;
+            x0x1.y = d0 - d2;
+        } else if (d1 != 0.0f) {
+            abc.x = vv1;
+            abc.y = (vv0 - vv1) * d1;
+            abc.z = (vv2 - vv1) * d1;
+            x0x1.x = d1 - d0;
+            x0x1.y = d1 - d2;
+        } else if (d2 != 0.0f) {
+            abc.x = vv2;
+            abc.y = (vv0 - vv2) * d2;
+            abc.z = (vv1 - vv2) * d2;
+            x0x1.x = d2 - d0;
+            x0x1.y = d2 - d1;
+        } else {
+            /* triangles are coplanar */
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean coplanarTriTri(Vector3f n, Vector3f v0, Vector3f v1,
+                                          Vector3f v2, Vector3f u0, Vector3f u1, Vector3f u2) {
+        Vector3f a = new Vector3f();
+        short i0, i1;
+        a.x = FastMath.abs(n.x);
+        a.y = FastMath.abs(n.y);
+        a.z = FastMath.abs(n.z);
+
+        if (a.x > a.y) {
+            if (a.x > a.z) {
+                i0 = 1; /* a[0] is greatest */
+                i1 = 2;
+            } else {
+                i0 = 0; /* a[2] is greatest */
+                i1 = 1;
+            }
+        } else /* a[0] <=a[1] */{
+            if (a.z > a.y) {
+                i0 = 0; /* a[2] is greatest */
+                i1 = 1;
+            } else {
+                i0 = 0; /* a[1] is greatest */
+                i1 = 2;
+            }
+        }
+
+        /* test all edges of triangle 1 against the edges of triangle 2 */
+        float[] v0f = new float[3];
+        v0.toArray(v0f);
+        float[] v1f = new float[3];
+        v1.toArray(v1f);
+        float[] v2f = new float[3];
+        v2.toArray(v2f);
+        float[] u0f = new float[3];
+        u0.toArray(u0f);
+        float[] u1f = new float[3];
+        u1.toArray(u1f);
+        float[] u2f = new float[3];
+        u2.toArray(u2f);
+        if (edgeAgainstTriEdges(v0f, v1f, u0f, u1f, u2f, i0, i1)) {
+            return true;
+        }
+
+        if (edgeAgainstTriEdges(v1f, v2f, u0f, u1f, u2f, i0, i1)) {
+            return true;
+        }
+
+        if (edgeAgainstTriEdges(v2f, v0f, u0f, u1f, u2f, i0, i1)) {
+            return true;
+        }
+
+        /* finally, test if tri1 is totally contained in tri2 or vice versa */
+        pointInTri(v0f, u0f, u1f, u2f, i0, i1);
+        pointInTri(u0f, v0f, v1f, v2f, i0, i1);
+
+        return false;
+    }
+
+    private static boolean pointInTri(float[] V0, float[] U0, float[] U1,
+                                      float[] U2, int i0, int i1) {
+        float a, b, c, d0, d1, d2;
+        /* is T1 completly inside T2? */
+        /* check if V0 is inside tri(U0,U1,U2) */
+        a = U1[i1] - U0[i1];
+        b = -(U1[i0] - U0[i0]);
+        c = -a * U0[i0] - b * U0[i1];
+        d0 = a * V0[i0] + b * V0[i1] + c;
+
+        a = U2[i1] - U1[i1];
+        b = -(U2[i0] - U1[i0]);
+        c = -a * U1[i0] - b * U1[i1];
+        d1 = a * V0[i0] + b * V0[i1] + c;
+
+        a = U0[i1] - U2[i1];
+        b = -(U0[i0] - U2[i0]);
+        c = -a * U2[i0] - b * U2[i1];
+        d2 = a * V0[i0] + b * V0[i1] + c;
+        if (d0 * d1 > 0.0 && d0 * d2 > 0.0)
+            return true;
+
+        return false;
+    }
+
+    private static boolean edgeAgainstTriEdges(float[] v0, float[] v1,
+                                               float[] u0, float[] u1, float[] u2, int i0, int i1) {
+        float aX, aY;
+        aX = v1[i0] - v0[i0];
+        aY = v1[i1] - v0[i1];
+        /* test edge u0,u1 against v0,v1 */
+        if (edgeEdgeTest(v0, u0, u1, i0, i1, aX, aY)) {
+            return true;
+        }
+        /* test edge u1,u2 against v0,v1 */
+        if (edgeEdgeTest(v0, u1, u2, i0, i1, aX, aY)) {
+            return true;
+        }
+        /* test edge u2,u1 against v0,v1 */
+        if (edgeEdgeTest(v0, u2, u0, i0, i1, aX, aY)) {
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean edgeEdgeTest(float[] v0, float[] u0, float[] u1,
+                                        int i0, int i1, float aX, float Ay) {
+        float Bx = u0[i0] - u1[i0];
+        float By = u0[i1] - u1[i1];
+        float Cx = v0[i0] - u0[i0];
+        float Cy = v0[i1] - u0[i1];
+        float f = Ay * Bx - aX * By;
+        float d = By * Cx - Bx * Cy;
+        if ((f > 0 && d >= 0 && d <= f) || (f < 0 && d <= 0 && d >= f)) {
+            float e = aX * Cy - Ay * Cx;
+            if (f > 0) {
+                if (e >= 0 && e <= f)
+                    return true;
+            } else {
+                if (e <= 0 && e >= f)
+                    return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/creativemd/littletiles/client/util3d/TriangleTriangleIntersect.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/TriangleTriangleIntersect.java
@@ -19,7 +19,7 @@ package com.creativemd.littletiles.client.util3d;
 import org.joml.Vector2f;
 import org.joml.Vector3f;
 
-public class TriangleIntersect {
+public class TriangleTriangleIntersect {
 
     /**
      * EPSILON represents the error buffer used to denote a hit.

--- a/src/main/java/com/creativemd/littletiles/client/util3d/TriangleTriangleIntersect.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/TriangleTriangleIntersect.java
@@ -24,7 +24,7 @@ public class TriangleTriangleIntersect {
     /**
      * EPSILON represents the error buffer used to denote a hit.
      */
-    public static final double EPSILON = 1e-12;
+    public static final double EPSILON = 1e-3;
 
     private static final Vector3f tempVa = new Vector3f();
 
@@ -120,7 +120,7 @@ public class TriangleTriangleIntersect {
         du0du1 = du0 * du1;
         du0du2 = du0 * du2;
 
-        if (du0du1 > 0.0f && du0du2 > 0.0f) {
+        if (du0du1 >= 0.0f && du0du2 >= 0.0f) {
             return false;
         }
 
@@ -218,7 +218,7 @@ public class TriangleTriangleIntersect {
         sort(isect1);
         sort(isect2);
 
-        if (isect1[1] < isect2[0] || isect2[1] < isect1[0]) {
+        if (isect1[1] < isect2[0] + EPSILON || isect2[1] < isect1[0] + EPSILON) {
             return false;
         }
 
@@ -280,6 +280,9 @@ public class TriangleTriangleIntersect {
 
     private static boolean coplanarTriTri(Vector3f n, Vector3f v0, Vector3f v1, Vector3f v2, Vector3f u0, Vector3f u1,
             Vector3f u2) {
+        if (true) {
+            return false; // We treat coplanar as nontouching
+        }
         Vector3f a = new Vector3f();
         short i0, i1;
         a.x = Math.abs(n.x);

--- a/src/main/java/com/creativemd/littletiles/common/items/ItemBlockTiles.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemBlockTiles.java
@@ -178,7 +178,7 @@ public class ItemBlockTiles extends ItemBlock implements ILittleTile, ITilesRend
             LittleStructure structure, int x, int y, int z, ItemStack stack, ArrayList<LittleTile> unplaceableTiles,
             LittleTileCutoutInfo cutoutInfo, LittleTilePlaceMode placeMode) {
         LittleTilePlacementPlan plan = new LittleTilePlacementPlan();
-        plan.fillPlan(world, x, y, z, previews, structure, placeMode);
+        plan.fillPlan(world, x, y, z, previews, structure, placeMode, cutoutInfo);
         if (!plan.canApplyPlan()) {
             return false;
         }

--- a/src/main/java/com/creativemd/littletiles/common/items/LittleTilePlacementPlan.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/LittleTilePlacementPlan.java
@@ -48,13 +48,15 @@ public class LittleTilePlacementPlan {
     private int originY;
     private int originZ;
     private LittleTileBox originalBox;
+    private LittleTileCutoutInfo cutoutInfo;
 
     public void fillPlan(World world, int x, int y, int z, ArrayList<PreviewTile> previews, LittleStructure structure,
-            LittleTilePlaceMode placeMode) {
+            LittleTilePlaceMode placeMode, LittleTileCutoutInfo cutoutInfo) {
         this.placeMode = placeMode;
         this.originX = x;
         this.originY = y;
         this.originZ = z;
+        this.cutoutInfo = cutoutInfo;
         if (previews.isEmpty()) {
             canApplyPlan = false;
             return;
@@ -122,7 +124,7 @@ public class LittleTilePlacementPlan {
 
             // Collision check against an existing LittleTiles TE. Special place mode bypasses this on
             // purpose — overriding collisions is its whole reason to exist.
-            if (!specialPlaceMode && tile != null && !isSpaceForTiles(tile, placeTiles)) {
+            if (!specialPlaceMode && tile != null && !isSpaceForTiles(tile, placeTiles, coord)) {
                 return false;
             }
 
@@ -165,7 +167,8 @@ public class LittleTilePlacementPlan {
             return false;
         }
 
-        List<LittleTile> tiles = placeTile.placeTile(player, stack, tile, structure, unplaceableTiles, placeMode);
+        List<LittleTile> tiles = placeTile
+                .placeTile(player, stack, tile, structure, unplaceableTiles, placeMode, cutoutInfoCurrent);
         if (tiles == null) {
             return false;
         }
@@ -173,7 +176,6 @@ public class LittleTilePlacementPlan {
         boolean didPlace = false;
         for (LittleTile littleTile : tiles) {
             didPlace = true;
-            littleTile.setCutoutInfo(cutoutInfoCurrent);
             if (structure != null) {
                 if (structureMainPosition == null) {
                     structure.mainTile = littleTile;
@@ -234,9 +236,19 @@ public class LittleTilePlacementPlan {
         return tile;
     }
 
-    private static boolean isSpaceForTiles(TileEntityLittleTiles mainTile, ArrayList<PreviewTile> placeTiles) {
-        for (PreviewTile tile : placeTiles)
-            if (tile.needsCollisionTest() && !(mainTile).isSpaceForLittleTile(tile.box)) return false;
+    private boolean isSpaceForTiles(TileEntityLittleTiles mainTile, ArrayList<PreviewTile> placeTiles,
+            ChunkCoordinates coord) {
+        for (PreviewTile tile : placeTiles) {
+            if (!tile.needsCollisionTest()) continue;
+            LittleTileCutoutInfo perTileCutout = null;
+            if (cutoutInfo != null) {
+                perTileCutout = new LittleTileCutoutInfo(cutoutInfo);
+                perTileCutout.pos.x += (originX - coord.posX) * 16 + originalBox.minX - tile.box.minX;
+                perTileCutout.pos.y += (originY - coord.posY) * 16 + originalBox.minY - tile.box.minY;
+                perTileCutout.pos.z += (originZ - coord.posZ) * 16 + originalBox.minZ - tile.box.minZ;
+            }
+            if (!mainTile.isSpaceForLittleTile(tile.box, perTileCutout)) return false;
+        }
         return true;
     }
 }

--- a/src/main/java/com/creativemd/littletiles/common/structure/PreviewTileAxis.java
+++ b/src/main/java/com/creativemd/littletiles/common/structure/PreviewTileAxis.java
@@ -10,6 +10,7 @@ import net.minecraft.util.Vec3;
 import com.creativemd.creativecore.common.utils.RotationUtils.Axis;
 import com.creativemd.littletiles.common.tileentity.TileEntityLittleTiles;
 import com.creativemd.littletiles.common.utils.LittleTile;
+import com.creativemd.littletiles.common.utils.LittleTileCutoutInfo;
 import com.creativemd.littletiles.common.utils.LittleTilePlaceMode;
 import com.creativemd.littletiles.common.utils.LittleTilePreview;
 import com.creativemd.littletiles.common.utils.small.LittleTileBox;
@@ -67,7 +68,8 @@ public class PreviewTileAxis extends PreviewTile {
 
     @Override
     public List<LittleTile> placeTile(EntityPlayer player, ItemStack stack, TileEntityLittleTiles teLT,
-            LittleStructure structure, ArrayList<LittleTile> unplaceableTiles, LittleTilePlaceMode placeMode) {
+            LittleStructure structure, ArrayList<LittleTile> unplaceableTiles, LittleTilePlaceMode placeMode,
+            LittleTileCutoutInfo cutoutInfo) {
         if (structure instanceof LittleDoor) {
             LittleDoor door = (LittleDoor) structure;
             door.axisVec = box.getMinVec(); // Check if this would be perfect

--- a/src/main/java/com/creativemd/littletiles/common/tileentity/TileEntityLittleTiles.java
+++ b/src/main/java/com/creativemd/littletiles/common/tileentity/TileEntityLittleTiles.java
@@ -18,8 +18,13 @@ import net.minecraft.util.Vec3;
 
 import com.creativemd.creativecore.common.utils.CubeObject;
 import com.creativemd.littletiles.LittleTiles;
+import com.creativemd.littletiles.client.util3d.Mesh3d;
+import com.creativemd.littletiles.client.util3d.Mesh3dUtil;
+import com.creativemd.littletiles.client.util3d.TriangleBoundingBoxIntersect;
+import com.creativemd.littletiles.client.util3d.TriangleTriangleIntersect;
 import com.creativemd.littletiles.common.structure.LittleStructure;
 import com.creativemd.littletiles.common.utils.LittleTile;
+import com.creativemd.littletiles.common.utils.LittleTileCutoutInfo;
 import com.creativemd.littletiles.common.utils.small.LittleTileBox;
 import com.creativemd.littletiles.common.utils.small.LittleTileVec;
 
@@ -149,6 +154,56 @@ public class TileEntityLittleTiles extends TileEntity {
             }
 
         }
+        return true;
+    }
+
+    public boolean isSpaceForLittleTile(LittleTileBox boxNewTile, LittleTileCutoutInfo cutoutNewTile) {
+        AxisAlignedBB aabbNewTile = boxNewTile.getBox();
+        Mesh3d meshNewTile = null;
+        if (!tiles.isEmpty() && cutoutNewTile != null) {
+            meshNewTile = Mesh3dUtil.meshFromTile(boxNewTile, cutoutNewTile);
+        }
+
+        for (LittleTile tile : tiles) {
+            if (tile.boundingBox == null) {
+                continue;
+            }
+
+            // Skip all checks if bounding boxes don't even collide
+            if (!aabbNewTile.intersectsWith(tile.boundingBox.getBox())) {
+                continue;
+            }
+
+            Mesh3d meshOldTile = null;
+            if (tile.getCutoutInfo() != null) {
+                meshOldTile = Mesh3dUtil.meshFromTile(tile.boundingBox, tile.getCutoutInfo());
+            }
+
+            if (meshOldTile == null) {
+                if (meshNewTile == null) {
+                    // Normal box-box collision
+                    return false;
+                } else {
+                    // Special box-mesh collision
+                    if (TriangleBoundingBoxIntersect.intersect(meshNewTile, tile.boundingBox)) {
+                        return false;
+                    }
+                }
+            } else {
+                if (meshNewTile == null) {
+                    // Special mesh-box collision
+                    if (TriangleBoundingBoxIntersect.intersect(meshOldTile, boxNewTile)) {
+                        return false;
+                    }
+                } else {
+                    // Special mesh-mesh collision
+                    if (TriangleTriangleIntersect.meshIntersection(meshNewTile, meshOldTile)) {
+                        return false;
+                    }
+                }
+            }
+        }
+
         return true;
     }
 

--- a/src/main/java/com/creativemd/littletiles/utils/PreviewTile.java
+++ b/src/main/java/com/creativemd/littletiles/utils/PreviewTile.java
@@ -12,6 +12,7 @@ import com.creativemd.creativecore.common.utils.HashMapList;
 import com.creativemd.littletiles.common.structure.LittleStructure;
 import com.creativemd.littletiles.common.tileentity.TileEntityLittleTiles;
 import com.creativemd.littletiles.common.utils.LittleTile;
+import com.creativemd.littletiles.common.utils.LittleTileCutoutInfo;
 import com.creativemd.littletiles.common.utils.LittleTilePlaceMode;
 import com.creativemd.littletiles.common.utils.LittleTilePreview;
 import com.creativemd.littletiles.common.utils.small.LittleTileBox;
@@ -95,12 +96,14 @@ public class PreviewTile {
     }
 
     public List<LittleTile> placeTile(EntityPlayer player, ItemStack stack, TileEntityLittleTiles teLT,
-            LittleStructure structure, ArrayList<LittleTile> unplaceableTiles, LittleTilePlaceMode placeMode) {
+            LittleStructure structure, ArrayList<LittleTile> unplaceableTiles, LittleTilePlaceMode placeMode,
+            LittleTileCutoutInfo cutoutInfoCurrent) {
         LittleTile LT = preview.getLittleTile(teLT);
         if (LT == null) return null;
 
         LT.boundingBox = box.copy();
         LT.updateCorner();
+        LT.setCutoutInfo(cutoutInfoCurrent);
 
         if (structure != null) {
             LT.isStructureBlock = true;
@@ -108,7 +111,7 @@ public class PreviewTile {
             structure.getTiles().add(LT);
         }
 
-        if (teLT.isSpaceForLittleTile(box.copy())) {
+        if (teLT.isSpaceForLittleTile(box.copy(), cutoutInfoCurrent)) {
             if (placeMode == LittleTilePlaceMode.STENCIL) {
                 return null;
             }


### PR DESCRIPTION
This PR shape aware placement logic - no longer will slopes (and other shapes) be treated as full cubes. That means you can now have two slopes touching, forming a full cube from two materials. Or just place more tiles in the free space a slope leaves.

Note that shape aware placement is NOT implemented yet. The only way to really test is to use "marked mode" (see keybinds).

I imported a bunch of code from JMonkeyEngine and adapted it for usage. That code I just assumed to be good-enough as is, and can probably be skipped for review.

I recommend reviewing this commit-by-commit.

### To test

1. Equip the Little Chisel
2. Place a slope with the flat side on the ground

<img width="150" src="https://github.com/user-attachments/assets/9fd4acde-7d29-4929-a3a4-8133d486c2ea" />

3. Point the chisel at the ground next to the slope
4. Press the Marked Mode keybind
5. Use the arrow keys to move the marker into the empty space left by the slope
6. Right-click to place a tile at the marker position
