### PR TITLE
Better edge sorting loop

### DIFF
--- a/src/main/java/com/creativemd/littletiles/client/util3d/Edge3d.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/Edge3d.java
@@ -7,42 +7,70 @@ import com.creativemd.creativecore.lib.Vector3d;
 
 public class Edge3d {
 
-    private Vector3d p1;
-    private Vector3d p2;
+    private static final double EPSILON = 0.0001;
+    private static final double EPSILON_SQUARED = EPSILON * EPSILON;
+
+    private static final class NextEdgeResult {
+
+        private Edge3d edge;
+        private Vector3d nextPoint;
+    }
+
+    private final Vector3d p1;
+    private final Vector3d p2;
 
     public Edge3d(Vector3d p1, Vector3d p2) {
         this.p1 = p1;
         this.p2 = p2;
     }
 
+    private static double distanceSquared(Vector3d a, Vector3d b) {
+        double dx = a.x - b.x;
+        double dy = a.y - b.y;
+        double dz = a.z - b.z;
+        return dx * dx + dy * dy + dz * dz;
+    }
+
+    private static boolean findNextBestEdge(Vector3d current, List<Edge3d> edges, NextEdgeResult result) {
+        double bestDistance = Double.POSITIVE_INFINITY;
+        result.edge = null;
+        result.nextPoint = null;
+        for (Edge3d edge : edges) {
+            double distance = distanceSquared(edge.p1, current);
+            if (distance < bestDistance) {
+                bestDistance = distance;
+                result.edge = edge;
+                result.nextPoint = edge.p2;
+            }
+
+            distance = distanceSquared(edge.p2, current);
+            if (distance < bestDistance) {
+                bestDistance = distance;
+                result.edge = edge;
+                result.nextPoint = edge.p1;
+            }
+        }
+        return bestDistance <= EPSILON_SQUARED;
+    }
+
     public static List<Vector3d> orderEdgesToVertexList(List<Edge3d> edges) {
         List<Vector3d> orderedLoop = new ArrayList<>();
+        NextEdgeResult nextEdge = new NextEdgeResult();
         Edge3d firstEdge = edges.get(0);
 
-        Vector3d prev = firstEdge.p1;
+        orderedLoop.add(firstEdge.p1);
+        orderedLoop.add(firstEdge.p2);
         Vector3d current = firstEdge.p2;
-        orderedLoop.add(prev);
-        orderedLoop.add(current);
+        edges.remove(0);
 
-        while (orderedLoop.size() < edges.size()) {
-            int orderedLoopSize = orderedLoop.size();
-            for (Edge3d edge : edges) {
-                if (edge.p1.equals(current) && !edge.p2.equals(prev)) {
-                    prev = current;
-                    current = edge.p2;
-                    orderedLoop.add(current);
-                    break;
-                } else if (edge.p2.equals(current) && !edge.p1.equals(prev)) {
-                    prev = current;
-                    current = edge.p1;
-                    orderedLoop.add(current);
-                    break;
-                }
-            }
-            if (orderedLoopSize == orderedLoop.size()) {
-                // Something went horribly wrong and we'd be stuck inside an endless loop
+        while (!edges.isEmpty()) {
+            if (!findNextBestEdge(current, edges, nextEdge)) {
+                // Closest endpoint is farther than epsilon — loop is broken
                 return null;
             }
+            edges.remove(nextEdge.edge);
+            current = nextEdge.nextPoint;
+            orderedLoop.add(current);
         }
 
         return orderedLoop;


### PR DESCRIPTION
## Summary
This PR introduces a new edge splitting algorithm to hopefully solve the issue with holes in complex cut slopes. This logic tries to avoid floating point equality checks at all.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
