### PR TITLE
Check faces of neighbouring tiles for culling

### DIFF
--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
@@ -8,10 +8,10 @@ import net.minecraft.block.BlockAir;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.init.Blocks;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.common.util.ForgeDirection;
-import net.minecraft.tileentity.TileEntity;
 
 import org.joml.Vector2d;
 import org.joml.Vector3i;
@@ -110,8 +110,8 @@ public class LittleTilesBlockRenderHelper {
         return !mesh.getTriangles().isEmpty();
     }
 
-    private static void addNeighbouringCubes(IBlockAccess world, ArrayList<ArrayList<LittleTilesCubeObject>> neighbours, int x, int y, int z, int dx, int dy, int dz)
-    {
+    private static void addNeighbouringCubes(IBlockAccess world, ArrayList<ArrayList<LittleTilesCubeObject>> neighbours,
+            int x, int y, int z, int dx, int dy, int dz) {
         TileEntity tileEntity = world.getTileEntity(x + dx, y + dy, z + dz);
         if (tileEntity instanceof TileEntityLittleTiles) {
             TileEntityLittleTiles little = (TileEntityLittleTiles) tileEntity;
@@ -125,33 +125,22 @@ public class LittleTilesBlockRenderHelper {
                 neighbourCubeObjects = tile.getRenderingCubes();
                 // Ignore any neighbouring cubes that are not adjacent to the block border
                 for (LittleTilesCubeObject cube : neighbourCubeObjects) {
-                    if (dx == 1)
-                    {
+                    if (dx == 1) {
                         if (cube.gridMinX != 0) continue;
                         neighbours.get(ForgeDirection.EAST.ordinal()).addAll(neighbourCubeObjects);
-                    }
-                    else if (dx == -1)
-                    {
+                    } else if (dx == -1) {
                         if (cube.gridMaxX != 16) continue;
                         neighbours.get(ForgeDirection.WEST.ordinal()).addAll(neighbourCubeObjects);
-                    }
-                    else if (dy == 1)
-                    {
+                    } else if (dy == 1) {
                         if (cube.gridMinY != 0) continue;
                         neighbours.get(ForgeDirection.UP.ordinal()).addAll(neighbourCubeObjects);
-                    }
-                    else if (dy == -1)
-                    {
+                    } else if (dy == -1) {
                         if (cube.gridMaxY != 16) continue;
                         neighbours.get(ForgeDirection.DOWN.ordinal()).addAll(neighbourCubeObjects);
-                    }
-                    else if (dz == 1)
-                    {
+                    } else if (dz == 1) {
                         if (cube.gridMinZ != 0) continue;
                         neighbours.get(ForgeDirection.SOUTH.ordinal()).addAll(neighbourCubeObjects);
-                    }
-                    else if (dz == -1)
-                    {
+                    } else if (dz == -1) {
                         if (cube.gridMaxZ != 16) continue;
                         neighbours.get(ForgeDirection.NORTH.ordinal()).addAll(neighbourCubeObjects);
                     }
@@ -173,8 +162,7 @@ public class LittleTilesBlockRenderHelper {
         boolean rendered = false;
 
         ArrayList<ArrayList<LittleTilesCubeObject>> neighbours = new ArrayList<ArrayList<LittleTilesCubeObject>>(6);
-        for (int i = 0; i < 6; i++)
-        {
+        for (int i = 0; i < 6; i++) {
             neighbours.add(i, new ArrayList<>());
         }
         addNeighbouringCubes(world, neighbours, x, y, z, 1, 0, 0);

--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
@@ -1,6 +1,7 @@
 package com.creativemd.littletiles.client.render;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockAir;
@@ -10,6 +11,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraft.tileentity.TileEntity;
 
 import org.joml.Vector2d;
 import org.joml.Vector3i;
@@ -24,6 +26,8 @@ import com.creativemd.littletiles.LittleTiles;
 import com.creativemd.littletiles.client.util3d.Mesh3d;
 import com.creativemd.littletiles.client.util3d.Mesh3dUtil;
 import com.creativemd.littletiles.client.util3d.Triangle3d;
+import com.creativemd.littletiles.common.tileentity.TileEntityLittleTiles;
+import com.creativemd.littletiles.common.utils.LittleTile;
 import com.creativemd.littletiles.common.utils.LittleTileCutoutInfo;
 import com.creativemd.littletiles.common.utils.LittleTileShapeMode;
 import com.creativemd.littletiles.common.utils.LittleTilesCubeObject;
@@ -106,6 +110,56 @@ public class LittleTilesBlockRenderHelper {
         return !mesh.getTriangles().isEmpty();
     }
 
+    private static void addNeighbouringCubes(IBlockAccess world, ArrayList<ArrayList<LittleTilesCubeObject>> neighbours, int x, int y, int z, int dx, int dy, int dz)
+    {
+        TileEntity tileEntity = world.getTileEntity(x + dx, y + dy, z + dz);
+        if (tileEntity instanceof TileEntityLittleTiles) {
+            TileEntityLittleTiles little = (TileEntityLittleTiles) tileEntity;
+            List<LittleTile> tiles = little.getTiles();
+            List<LittleTile> snapshot;
+            synchronized (tiles) {
+                snapshot = new ArrayList<>(tiles);
+            }
+            for (LittleTile tile : snapshot) {
+                ArrayList<LittleTilesCubeObject> neighbourCubeObjects = new ArrayList<>();
+                neighbourCubeObjects = tile.getRenderingCubes();
+                // Ignore any neighbouring cubes that are not adjacent to the block border
+                for (LittleTilesCubeObject cube : neighbourCubeObjects) {
+                    if (dx == 1)
+                    {
+                        if (cube.gridMinX != 0) continue;
+                        neighbours.get(ForgeDirection.EAST.ordinal()).addAll(neighbourCubeObjects);
+                    }
+                    else if (dx == -1)
+                    {
+                        if (cube.gridMaxX != 16) continue;
+                        neighbours.get(ForgeDirection.WEST.ordinal()).addAll(neighbourCubeObjects);
+                    }
+                    else if (dy == 1)
+                    {
+                        if (cube.gridMinY != 0) continue;
+                        neighbours.get(ForgeDirection.UP.ordinal()).addAll(neighbourCubeObjects);
+                    }
+                    else if (dy == -1)
+                    {
+                        if (cube.gridMaxY != 16) continue;
+                        neighbours.get(ForgeDirection.DOWN.ordinal()).addAll(neighbourCubeObjects);
+                    }
+                    else if (dz == 1)
+                    {
+                        if (cube.gridMinZ != 0) continue;
+                        neighbours.get(ForgeDirection.SOUTH.ordinal()).addAll(neighbourCubeObjects);
+                    }
+                    else if (dz == -1)
+                    {
+                        if (cube.gridMaxZ != 16) continue;
+                        neighbours.get(ForgeDirection.NORTH.ordinal()).addAll(neighbourCubeObjects);
+                    }
+                }
+            }
+        }
+    }
+
     public static boolean renderCubes(IBlockAccess world, ArrayList<LittleTilesCubeObject> cubes, int x, int y, int z,
             Block block, RenderBlocks renderer, ForgeDirection direction) {
 
@@ -118,7 +172,19 @@ public class LittleTilesBlockRenderHelper {
         int pass = ForgeHooksClient.getWorldRenderPass();
         boolean rendered = false;
 
-        LittleTilesFaceCuller.computeHiddenSides(cubes);
+        ArrayList<ArrayList<LittleTilesCubeObject>> neighbours = new ArrayList<ArrayList<LittleTilesCubeObject>>(6);
+        for (int i = 0; i < 6; i++)
+        {
+            neighbours.add(i, new ArrayList<>());
+        }
+        addNeighbouringCubes(world, neighbours, x, y, z, 1, 0, 0);
+        addNeighbouringCubes(world, neighbours, x, y, z, -1, 0, 0);
+        addNeighbouringCubes(world, neighbours, x, y, z, 0, 1, 0);
+        addNeighbouringCubes(world, neighbours, x, y, z, 0, -1, 0);
+        addNeighbouringCubes(world, neighbours, x, y, z, 0, 0, 1);
+        addNeighbouringCubes(world, neighbours, x, y, z, 0, 0, -1);
+
+        LittleTilesFaceCuller.computeHiddenSides(cubes, neighbours);
 
         try {
             for (int i = 0; i < cubes.size(); i++) {

--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
@@ -1,5 +1,6 @@
 package com.creativemd.littletiles.client.render;
 
+import net.minecraftforge.common.util.ForgeDirection;
 import static net.minecraftforge.common.util.ForgeDirection.DOWN;
 import static net.minecraftforge.common.util.ForgeDirection.EAST;
 import static net.minecraftforge.common.util.ForgeDirection.NORTH;
@@ -8,6 +9,7 @@ import static net.minecraftforge.common.util.ForgeDirection.UP;
 import static net.minecraftforge.common.util.ForgeDirection.WEST;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import com.creativemd.littletiles.common.utils.LittleTilesCubeObject;
 
@@ -32,13 +34,14 @@ public class LittleTilesFaceCuller {
      * Must be given all cubes, not just the ones of the current render pass: an opaque tile drawn
      * in pass 0 still hides the faces of a translucent tile drawn in pass 1.
      */
-    public static void computeHiddenSides(List<LittleTilesCubeObject> cubes) {
+    public static void computeHiddenSides(List<LittleTilesCubeObject> cubes, ArrayList<ArrayList<LittleTilesCubeObject>> neighbourCubes) {
         for (int i = 0; i < cubes.size(); i++) {
             final LittleTilesCubeObject cube = cubes.get(i);
             cube.hiddenSides = 0;
             if (ignoreForCulling(cube) || cube.block.isOpaqueCube()) {
                 continue;
             }
+            // Process the primary cube for internal hidden faces
             for (int j = 0; j < cubes.size(); j++) {
                 if (j == i) {
                     continue;
@@ -46,6 +49,16 @@ public class LittleTilesFaceCuller {
                 final LittleTilesCubeObject occluder = cubes.get(j);
                 if (canOcclude(occluder, cube)) {
                     cube.hiddenSides |= coveredSides(cube, occluder);
+                }
+            }
+            // Check the neighboring cubes.
+            for (int j = 0; j < 6; j++) {
+                final List<LittleTilesCubeObject> neighbourCubeObjects = neighbourCubes.get(j);
+                for (int k = 0; k < neighbourCubeObjects.size(); k++) {
+                    final LittleTilesCubeObject occluder = neighbourCubeObjects.get(k);
+                    if (canOcclude(occluder, cube)) {
+                        cube.hiddenSides |= coveredNeighbourSides(cube, occluder, j);
+                    }
                 }
             }
         }
@@ -94,6 +107,65 @@ public class LittleTilesFaceCuller {
             if (occluder.gridMinX == cube.gridMaxX) hidden |= EAST.flag;
         }
 
+        return hidden;
+    }
+
+    /**
+     * Bit mask of the faces of {@code cube}'s neighbouring blocks that {@code occluder} sits flush against and fully
+     * covers on its own. Faces that are only partially covered, or covered by several occluders
+     * together, are not detected. Essentially the same as {@code coveredSides}, but only checking one face of the cube.
+     */
+    private static int coveredNeighbourSides(LittleTilesCubeObject cube, LittleTilesCubeObject occluder, int side) {
+        int hidden = 0;
+
+        ForgeDirection direction = ForgeDirection.getOrientation(side);
+        switch (direction) {
+            case DOWN:
+            {
+                if (occluder.gridMinX <= cube.gridMinX && occluder.gridMaxX >= cube.gridMaxX &&
+                    occluder.gridMinZ <= cube.gridMinZ && occluder.gridMaxZ >= cube.gridMaxZ &&
+                    occluder.gridMaxY == 16 && cube.gridMinY == 0) hidden |= DOWN.flag;
+                break;
+            }
+            case UP:
+            {
+                if (occluder.gridMinX <= cube.gridMinX && occluder.gridMaxX >= cube.gridMaxX &&
+                    occluder.gridMinZ <= cube.gridMinZ && occluder.gridMaxZ >= cube.gridMaxZ &&
+                    occluder.gridMinY == 0 && cube.gridMaxY == 16) hidden |= UP.flag;
+                break;
+            }
+            case NORTH:
+            {
+                if (occluder.gridMinX <= cube.gridMinX && occluder.gridMaxX >= cube.gridMaxX &&
+                    occluder.gridMinY <= cube.gridMinY && occluder.gridMaxY >= cube.gridMaxY &&
+                    occluder.gridMaxZ == 16 && cube.gridMinZ == 0) hidden |= NORTH.flag;
+                break;
+            }
+            case SOUTH:
+            {
+                if (occluder.gridMinX <= cube.gridMinX && occluder.gridMaxX >= cube.gridMaxX &&
+                    occluder.gridMinY <= cube.gridMinY && occluder.gridMaxY >= cube.gridMaxY &&
+                    occluder.gridMinZ == 0 && cube.gridMaxZ == 16) hidden |= SOUTH.flag;
+                break;
+            }
+            case WEST:
+            {
+                if (occluder.gridMinY <= cube.gridMinY && occluder.gridMaxY >= cube.gridMaxY &&
+                    occluder.gridMinZ <= cube.gridMinZ && occluder.gridMaxZ >= cube.gridMaxZ &&
+                    occluder.gridMaxX == 16 && cube.gridMinX == 0) hidden |= WEST.flag;
+                break;
+            }
+            case EAST:
+            {
+                if (occluder.gridMinY <= cube.gridMinY && occluder.gridMaxY >= cube.gridMaxY &&
+                    occluder.gridMinZ <= cube.gridMinZ && occluder.gridMaxZ >= cube.gridMaxZ &&
+                    occluder.gridMinX == 0 && cube.gridMaxX == 16) hidden |= EAST.flag;
+                break;
+            }
+            default:
+                break;
+        }
+        
         return hidden;
     }
 }

--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
@@ -1,6 +1,5 @@
 package com.creativemd.littletiles.client.render;
 
-import net.minecraftforge.common.util.ForgeDirection;
 import static net.minecraftforge.common.util.ForgeDirection.DOWN;
 import static net.minecraftforge.common.util.ForgeDirection.EAST;
 import static net.minecraftforge.common.util.ForgeDirection.NORTH;
@@ -8,8 +7,10 @@ import static net.minecraftforge.common.util.ForgeDirection.SOUTH;
 import static net.minecraftforge.common.util.ForgeDirection.UP;
 import static net.minecraftforge.common.util.ForgeDirection.WEST;
 
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraftforge.common.util.ForgeDirection;
 
 import com.creativemd.littletiles.common.utils.LittleTilesCubeObject;
 
@@ -19,9 +20,9 @@ import cpw.mods.fml.relauncher.SideOnly;
 /**
  * Decides which faces of a tile entity's cubes are hidden by other cubes of the same tile entity.
  * <p>
- * Two touching translucent faces would otherwise blend against each other and darken the seam, and
- * every hidden face still costs a quad. The result is written to {@link LittleTilesCubeObject#hiddenSides}
- * and consumed by ExtendedRenderBlocks, which skips the matching renderFace* call.
+ * Two touching translucent faces would otherwise blend against each other and darken the seam, and every hidden face
+ * still costs a quad. The result is written to {@link LittleTilesCubeObject#hiddenSides} and consumed by
+ * ExtendedRenderBlocks, which skips the matching renderFace* call.
  */
 @SideOnly(Side.CLIENT)
 public class LittleTilesFaceCuller {
@@ -31,10 +32,11 @@ public class LittleTilesFaceCuller {
     /**
      * Computes {@link LittleTilesCubeObject#hiddenSides} for every cube of one tile entity.
      * <p>
-     * Must be given all cubes, not just the ones of the current render pass: an opaque tile drawn
-     * in pass 0 still hides the faces of a translucent tile drawn in pass 1.
+     * Must be given all cubes, not just the ones of the current render pass: an opaque tile drawn in pass 0 still hides
+     * the faces of a translucent tile drawn in pass 1.
      */
-    public static void computeHiddenSides(List<LittleTilesCubeObject> cubes, ArrayList<ArrayList<LittleTilesCubeObject>> neighbourCubes) {
+    public static void computeHiddenSides(List<LittleTilesCubeObject> cubes,
+            ArrayList<ArrayList<LittleTilesCubeObject>> neighbourCubes) {
         for (int i = 0; i < cubes.size(); i++) {
             final LittleTilesCubeObject cube = cubes.get(i);
             cube.hiddenSides = 0;
@@ -82,27 +84,29 @@ public class LittleTilesFaceCuller {
     }
 
     /**
-     * Bit mask of the faces of {@code cube} that {@code occluder} sits flush against and fully
-     * covers on its own. Faces that are only partially covered, or covered by several occluders
-     * together, are not detected.
+     * Bit mask of the faces of {@code cube} that {@code occluder} sits flush against and fully covers on its own. Faces
+     * that are only partially covered, or covered by several occluders together, are not detected.
      */
     private static int coveredSides(LittleTilesCubeObject cube, LittleTilesCubeObject occluder) {
         int hidden = 0;
 
         if (occluder.gridMinX <= cube.gridMinX && occluder.gridMaxX >= cube.gridMaxX
-                && occluder.gridMinZ <= cube.gridMinZ && occluder.gridMaxZ >= cube.gridMaxZ) {
+                && occluder.gridMinZ <= cube.gridMinZ
+                && occluder.gridMaxZ >= cube.gridMaxZ) {
             if (occluder.gridMaxY == cube.gridMinY) hidden |= DOWN.flag;
             if (occluder.gridMinY == cube.gridMaxY) hidden |= UP.flag;
         }
 
         if (occluder.gridMinX <= cube.gridMinX && occluder.gridMaxX >= cube.gridMaxX
-                && occluder.gridMinY <= cube.gridMinY && occluder.gridMaxY >= cube.gridMaxY) {
+                && occluder.gridMinY <= cube.gridMinY
+                && occluder.gridMaxY >= cube.gridMaxY) {
             if (occluder.gridMaxZ == cube.gridMinZ) hidden |= NORTH.flag;
             if (occluder.gridMinZ == cube.gridMaxZ) hidden |= SOUTH.flag;
         }
 
         if (occluder.gridMinY <= cube.gridMinY && occluder.gridMaxY >= cube.gridMaxY
-                && occluder.gridMinZ <= cube.gridMinZ && occluder.gridMaxZ >= cube.gridMaxZ) {
+                && occluder.gridMinZ <= cube.gridMinZ
+                && occluder.gridMaxZ >= cube.gridMaxZ) {
             if (occluder.gridMaxX == cube.gridMinX) hidden |= WEST.flag;
             if (occluder.gridMinX == cube.gridMaxX) hidden |= EAST.flag;
         }
@@ -112,60 +116,72 @@ public class LittleTilesFaceCuller {
 
     /**
      * Bit mask of the faces of {@code cube}'s neighbouring blocks that {@code occluder} sits flush against and fully
-     * covers on its own. Faces that are only partially covered, or covered by several occluders
-     * together, are not detected. Essentially the same as {@code coveredSides}, but only checking one face of the cube.
+     * covers on its own. Faces that are only partially covered, or covered by several occluders together, are not
+     * detected. Essentially the same as {@code coveredSides}, but only checking one face of the cube.
      */
     private static int coveredNeighbourSides(LittleTilesCubeObject cube, LittleTilesCubeObject occluder, int side) {
         int hidden = 0;
 
         ForgeDirection direction = ForgeDirection.getOrientation(side);
         switch (direction) {
-            case DOWN:
-            {
-                if (occluder.gridMinX <= cube.gridMinX && occluder.gridMaxX >= cube.gridMaxX &&
-                    occluder.gridMinZ <= cube.gridMinZ && occluder.gridMaxZ >= cube.gridMaxZ &&
-                    occluder.gridMaxY == 16 && cube.gridMinY == 0) hidden |= DOWN.flag;
+            case DOWN: {
+                if (occluder.gridMinX <= cube.gridMinX && occluder.gridMaxX >= cube.gridMaxX
+                        && occluder.gridMinZ <= cube.gridMinZ
+                        && occluder.gridMaxZ >= cube.gridMaxZ
+                        && occluder.gridMaxY == 16
+                        && cube.gridMinY == 0)
+                    hidden |= DOWN.flag;
                 break;
             }
-            case UP:
-            {
-                if (occluder.gridMinX <= cube.gridMinX && occluder.gridMaxX >= cube.gridMaxX &&
-                    occluder.gridMinZ <= cube.gridMinZ && occluder.gridMaxZ >= cube.gridMaxZ &&
-                    occluder.gridMinY == 0 && cube.gridMaxY == 16) hidden |= UP.flag;
+            case UP: {
+                if (occluder.gridMinX <= cube.gridMinX && occluder.gridMaxX >= cube.gridMaxX
+                        && occluder.gridMinZ <= cube.gridMinZ
+                        && occluder.gridMaxZ >= cube.gridMaxZ
+                        && occluder.gridMinY == 0
+                        && cube.gridMaxY == 16)
+                    hidden |= UP.flag;
                 break;
             }
-            case NORTH:
-            {
-                if (occluder.gridMinX <= cube.gridMinX && occluder.gridMaxX >= cube.gridMaxX &&
-                    occluder.gridMinY <= cube.gridMinY && occluder.gridMaxY >= cube.gridMaxY &&
-                    occluder.gridMaxZ == 16 && cube.gridMinZ == 0) hidden |= NORTH.flag;
+            case NORTH: {
+                if (occluder.gridMinX <= cube.gridMinX && occluder.gridMaxX >= cube.gridMaxX
+                        && occluder.gridMinY <= cube.gridMinY
+                        && occluder.gridMaxY >= cube.gridMaxY
+                        && occluder.gridMaxZ == 16
+                        && cube.gridMinZ == 0)
+                    hidden |= NORTH.flag;
                 break;
             }
-            case SOUTH:
-            {
-                if (occluder.gridMinX <= cube.gridMinX && occluder.gridMaxX >= cube.gridMaxX &&
-                    occluder.gridMinY <= cube.gridMinY && occluder.gridMaxY >= cube.gridMaxY &&
-                    occluder.gridMinZ == 0 && cube.gridMaxZ == 16) hidden |= SOUTH.flag;
+            case SOUTH: {
+                if (occluder.gridMinX <= cube.gridMinX && occluder.gridMaxX >= cube.gridMaxX
+                        && occluder.gridMinY <= cube.gridMinY
+                        && occluder.gridMaxY >= cube.gridMaxY
+                        && occluder.gridMinZ == 0
+                        && cube.gridMaxZ == 16)
+                    hidden |= SOUTH.flag;
                 break;
             }
-            case WEST:
-            {
-                if (occluder.gridMinY <= cube.gridMinY && occluder.gridMaxY >= cube.gridMaxY &&
-                    occluder.gridMinZ <= cube.gridMinZ && occluder.gridMaxZ >= cube.gridMaxZ &&
-                    occluder.gridMaxX == 16 && cube.gridMinX == 0) hidden |= WEST.flag;
+            case WEST: {
+                if (occluder.gridMinY <= cube.gridMinY && occluder.gridMaxY >= cube.gridMaxY
+                        && occluder.gridMinZ <= cube.gridMinZ
+                        && occluder.gridMaxZ >= cube.gridMaxZ
+                        && occluder.gridMaxX == 16
+                        && cube.gridMinX == 0)
+                    hidden |= WEST.flag;
                 break;
             }
-            case EAST:
-            {
-                if (occluder.gridMinY <= cube.gridMinY && occluder.gridMaxY >= cube.gridMaxY &&
-                    occluder.gridMinZ <= cube.gridMinZ && occluder.gridMaxZ >= cube.gridMaxZ &&
-                    occluder.gridMinX == 0 && cube.gridMaxX == 16) hidden |= EAST.flag;
+            case EAST: {
+                if (occluder.gridMinY <= cube.gridMinY && occluder.gridMaxY >= cube.gridMaxY
+                        && occluder.gridMinZ <= cube.gridMinZ
+                        && occluder.gridMaxZ >= cube.gridMaxZ
+                        && occluder.gridMinX == 0
+                        && cube.gridMaxX == 16)
+                    hidden |= EAST.flag;
                 break;
             }
             default:
                 break;
         }
-        
+
         return hidden;
     }
 }

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTilesCubeObject.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTilesCubeObject.java
@@ -14,8 +14,8 @@ public class LittleTilesCubeObject extends CubeObject {
     public int hiddenSides;
 
     /**
-     * Bounds on the 1/16 grid. Kept alongside the double bounds so face occlusion can be
-     * computed with exact integer math.
+     * Bounds on the 1/16 grid. Kept alongside the double bounds so face occlusion can be computed with exact integer
+     * math.
      */
     public int gridMinX, gridMinY, gridMinZ, gridMaxX, gridMaxY, gridMaxZ;
 


### PR DESCRIPTION
Adds neighbouring block checks for face culling. Only considers tiles that are bordering the 16x16x16 grid in each specific direction.

<img width="1139" height="970" alt="image" src="https://github.com/user-attachments/assets/8d41068a-e759-4a41-ab75-27392ed96c2d" />
