### PR TITLE
Improved face culling, including meshes

### DIFF
--- a/src/main/java/com/creativemd/creativecore/client/rendering/ExtendedRenderBlocks.java
+++ b/src/main/java/com/creativemd/creativecore/client/rendering/ExtendedRenderBlocks.java
@@ -1,11 +1,14 @@
 package com.creativemd.creativecore.client.rendering;
 
+import java.util.List;
+
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import com.creativemd.creativecore.client.block.IBlockAccessFake;
 import com.creativemd.creativecore.common.utils.ColorUtils;
@@ -16,6 +19,7 @@ public class ExtendedRenderBlocks extends RenderBlocks {
 
     public int side = -1;
     public int color = ColorUtils.WHITE;
+    public IFaceClipper faceClipper;
 
     @Override
     public IIcon getBlockIcon(Block par1Block, IBlockAccess par2IBlockAccess, int par3, int par4, int par5, int par6) {
@@ -41,6 +45,100 @@ public class ExtendedRenderBlocks extends RenderBlocks {
         this.useInventoryTint = renderer.useInventoryTint;
         this.renderFromInside = renderer.renderFromInside;
         this.enableAO = renderer.enableAO;
+    }
+
+    @Override
+    public void renderFaceYNeg(Block block, double x, double y, double z, IIcon icon) {
+        renderClippedFace(ForgeDirection.DOWN, block, x, y, z, icon);
+    }
+
+    @Override
+    public void renderFaceYPos(Block block, double x, double y, double z, IIcon icon) {
+        renderClippedFace(ForgeDirection.UP, block, x, y, z, icon);
+    }
+
+    @Override
+    public void renderFaceZNeg(Block block, double x, double y, double z, IIcon icon) {
+        renderClippedFace(ForgeDirection.NORTH, block, x, y, z, icon);
+    }
+
+    @Override
+    public void renderFaceZPos(Block block, double x, double y, double z, IIcon icon) {
+        renderClippedFace(ForgeDirection.SOUTH, block, x, y, z, icon);
+    }
+
+    @Override
+    public void renderFaceXNeg(Block block, double x, double y, double z, IIcon icon) {
+        renderClippedFace(ForgeDirection.WEST, block, x, y, z, icon);
+    }
+
+    @Override
+    public void renderFaceXPos(Block block, double x, double y, double z, IIcon icon) {
+        renderClippedFace(ForgeDirection.EAST, block, x, y, z, icon);
+    }
+
+    private void renderClippedFace(ForgeDirection side, Block block, double x, double y, double z, IIcon icon) {
+        List<FacePiece> pieces = faceClipper != null ? faceClipper.getFacePieces(side) : null;
+        if (pieces == null) {
+            renderWholeFace(side, block, x, y, z, icon);
+            return;
+        }
+
+        double oldMinX = renderMinX;
+        double oldMinY = renderMinY;
+        double oldMinZ = renderMinZ;
+        double oldMaxX = renderMaxX;
+        double oldMaxY = renderMaxY;
+        double oldMaxZ = renderMaxZ;
+        try {
+            for (FacePiece piece : pieces) {
+                setFacePieceBounds(side, piece);
+                renderWholeFace(side, block, x, y, z, icon);
+            }
+        } finally {
+            renderMinX = oldMinX;
+            renderMinY = oldMinY;
+            renderMinZ = oldMinZ;
+            renderMaxX = oldMaxX;
+            renderMaxY = oldMaxY;
+            renderMaxZ = oldMaxZ;
+        }
+    }
+
+    private void renderWholeFace(ForgeDirection side, Block block, double x, double y, double z, IIcon icon) {
+        switch (side) {
+            case DOWN -> super.renderFaceYNeg(block, x, y, z, icon);
+            case UP -> super.renderFaceYPos(block, x, y, z, icon);
+            case NORTH -> super.renderFaceZNeg(block, x, y, z, icon);
+            case SOUTH -> super.renderFaceZPos(block, x, y, z, icon);
+            case WEST -> super.renderFaceXNeg(block, x, y, z, icon);
+            case EAST -> super.renderFaceXPos(block, x, y, z, icon);
+            default -> {}
+        }
+    }
+
+    private void setFacePieceBounds(ForgeDirection side, FacePiece piece) {
+        switch (side) {
+            case DOWN, UP -> {
+                renderMinX = piece.minPlaneX / 16.0D;
+                renderMaxX = piece.maxPlaneX / 16.0D;
+                renderMinZ = piece.minPlaneY / 16.0D;
+                renderMaxZ = piece.maxPlaneY / 16.0D;
+            }
+            case NORTH, SOUTH -> {
+                renderMinX = piece.minPlaneX / 16.0D;
+                renderMaxX = piece.maxPlaneX / 16.0D;
+                renderMinY = piece.minPlaneY / 16.0D;
+                renderMaxY = piece.maxPlaneY / 16.0D;
+            }
+            case WEST, EAST -> {
+                renderMinZ = piece.minPlaneX / 16.0D;
+                renderMaxZ = piece.maxPlaneX / 16.0D;
+                renderMinY = piece.minPlaneY / 16.0D;
+                renderMaxY = piece.maxPlaneY / 16.0D;
+            }
+            default -> {}
+        }
     }
 
     @Override

--- a/src/main/java/com/creativemd/creativecore/client/rendering/FacePiece.java
+++ b/src/main/java/com/creativemd/creativecore/client/rendering/FacePiece.java
@@ -1,0 +1,21 @@
+package com.creativemd.creativecore.client.rendering;
+
+/**
+ * An axis aligned part of a block face, in the two axes spanning that face's plane.
+ * <p>
+ * Coordinates are in sixteenths of a block, so all clipping is exact integer math.
+ */
+public class FacePiece {
+
+    public final int minPlaneX;
+    public final int minPlaneY;
+    public final int maxPlaneX;
+    public final int maxPlaneY;
+
+    public FacePiece(int minPlaneX, int maxPlaneX, int minPlaneY, int maxPlaneY) {
+        this.minPlaneX = minPlaneX;
+        this.maxPlaneX = maxPlaneX;
+        this.minPlaneY = minPlaneY;
+        this.maxPlaneY = maxPlaneY;
+    }
+}

--- a/src/main/java/com/creativemd/creativecore/client/rendering/IFaceClipper.java
+++ b/src/main/java/com/creativemd/creativecore/client/rendering/IFaceClipper.java
@@ -1,0 +1,14 @@
+package com.creativemd.creativecore.client.rendering;
+
+import java.util.List;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+public interface IFaceClipper {
+
+    /**
+     * The visible parts of the given side, or null if the whole face should be rendered. An empty list means the face
+     * is fully hidden.
+     */
+    List<FacePiece> getFacePieces(ForgeDirection side);
+}

--- a/src/main/java/com/creativemd/creativecore/common/utils/RotationUtils.java
+++ b/src/main/java/com/creativemd/creativecore/common/utils/RotationUtils.java
@@ -8,17 +8,17 @@ public class RotationUtils {
 
     public static enum Axis {
 
-        Xaxis,
-        Yaxis,
-        Zaxis;
+        AxisX,
+        AxisY,
+        AxisZ;
 
         public boolean isAxis(ForgeDirection direction) {
             switch (this) {
-                case Xaxis:
+                case AxisX:
                     return direction == ForgeDirection.EAST || direction == ForgeDirection.WEST;
-                case Yaxis:
+                case AxisY:
                     return direction == ForgeDirection.UP || direction == ForgeDirection.DOWN;
-                case Zaxis:
+                case AxisZ:
                     return direction == ForgeDirection.SOUTH || direction == ForgeDirection.NORTH;
                 default:
                     return false;
@@ -27,11 +27,11 @@ public class RotationUtils {
 
         public int toInt() {
             switch (this) {
-                case Xaxis:
+                case AxisX:
                     return 0;
-                case Yaxis:
+                case AxisY:
                     return 1;
-                case Zaxis:
+                case AxisZ:
                     return 2;
                 default:
                     return 0;
@@ -40,11 +40,11 @@ public class RotationUtils {
 
         public ForgeDirection getDirection() {
             switch (this) {
-                case Xaxis:
+                case AxisX:
                     return ForgeDirection.EAST;
-                case Yaxis:
+                case AxisY:
                     return ForgeDirection.UP;
-                case Zaxis:
+                case AxisZ:
                     return ForgeDirection.SOUTH;
                 default:
                     return ForgeDirection.UNKNOWN;
@@ -52,16 +52,16 @@ public class RotationUtils {
         }
 
         public static Axis getAxis(ForgeDirection direction) {
-            if (direction == ForgeDirection.EAST || direction == ForgeDirection.WEST) return Axis.Xaxis;
-            if (direction == ForgeDirection.UP || direction == ForgeDirection.DOWN) return Axis.Yaxis;
-            if (direction == ForgeDirection.SOUTH || direction == ForgeDirection.NORTH) return Axis.Zaxis;
+            if (direction == ForgeDirection.EAST || direction == ForgeDirection.WEST) return Axis.AxisX;
+            if (direction == ForgeDirection.UP || direction == ForgeDirection.DOWN) return Axis.AxisY;
+            if (direction == ForgeDirection.SOUTH || direction == ForgeDirection.NORTH) return Axis.AxisZ;
             return null;
         }
 
         public static Axis getAxis(int id) {
-            if (id == 0) return Xaxis;
-            if (id == 1) return Yaxis;
-            if (id == 2) return Zaxis;
+            if (id == 0) return AxisX;
+            if (id == 1) return AxisY;
+            if (id == 2) return AxisZ;
             return null;
         }
     }

--- a/src/main/java/com/creativemd/littletiles/client/render/FaceClipper.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/FaceClipper.java
@@ -1,0 +1,112 @@
+package com.creativemd.littletiles.client.render;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+import com.creativemd.creativecore.client.rendering.FacePiece;
+import com.creativemd.creativecore.client.rendering.IFaceClipper;
+import com.creativemd.littletiles.common.utils.LittleTilesCubeObject;
+
+/**
+ * Collects covered areas of one box's faces and works out which parts of a face to draw.
+ * <p>
+ * All coordinates are in sixteenths of a block, matching the grid the boxes are placed on, so the clipping is exact
+ * integer math.
+ */
+public class FaceClipper implements IFaceClipper {
+
+    /** The box's own bounds, so a face only has to be identified by its side. */
+    private final int minX, minY, minZ, maxX, maxY, maxZ;
+
+    @SuppressWarnings("unchecked")
+    private final List<FacePiece>[] covers = new List[6];
+
+    public FaceClipper(LittleTilesCubeObject cube) {
+        this.minX = cube.gridMinX;
+        this.minY = cube.gridMinY;
+        this.minZ = cube.gridMinZ;
+        this.maxX = cube.gridMaxX;
+        this.maxY = cube.gridMaxY;
+        this.maxZ = cube.gridMaxZ;
+    }
+
+    /** Marks the given area of a side as hidden, in the axes spanning that side's plane. */
+    public void cover(ForgeDirection side, int minPlaneX, int minPlaneY, int maxPlaneX, int maxPlaneY) {
+        List<FacePiece> sideCovers = covers[side.ordinal()];
+        if (sideCovers == null) {
+            sideCovers = new ArrayList<>();
+            covers[side.ordinal()] = sideCovers;
+        }
+        sideCovers.add(new FacePiece(minPlaneX, maxPlaneX, minPlaneY, maxPlaneY));
+    }
+
+    @Override
+    public List<FacePiece> getFacePieces(ForgeDirection side) {
+        List<FacePiece> sideCovers = covers[side.ordinal()];
+        if (sideCovers == null) {
+            return null;
+        }
+
+        List<FacePiece> remaining = new ArrayList<>();
+        remaining.add(face(side));
+        boolean clipped = false;
+        for (FacePiece cover : sideCovers) {
+            List<FacePiece> newFaces = new ArrayList<>();
+            for (FacePiece piece : remaining) {
+                clipped |= cutFace(newFaces, piece, cover);
+            }
+            remaining = newFaces;
+            if (remaining.isEmpty()) {
+                break;
+            }
+        }
+        return clipped ? remaining : null;
+    }
+
+    /** The whole area of one side, in that side's plane axes. */
+    private FacePiece face(ForgeDirection side) {
+        return switch (side) {
+            case DOWN, UP -> new FacePiece(minX, maxX, minZ, maxZ);
+            case NORTH, SOUTH -> new FacePiece(minX, maxX, minY, maxY);
+            default -> new FacePiece(minZ, maxZ, minY, maxY);
+        };
+    }
+
+    /**
+     * Splits {@code piece} into up to four pieces around the part {@code cover} hides, appending them to
+     * {@code result}. Returns whether anything was actually cut away.
+     */
+    private static boolean cutFace(List<FacePiece> result, FacePiece piece, FacePiece cover) {
+        // Clamp the cover to the part of the piece it actually overlaps.
+        int minPlaneX = Math.max(piece.minPlaneX, cover.minPlaneX);
+        int minPlaneY = Math.max(piece.minPlaneY, cover.minPlaneY);
+        int maxPlaneX = Math.min(piece.maxPlaneX, cover.maxPlaneX);
+        int maxPlaneY = Math.min(piece.maxPlaneY, cover.maxPlaneY);
+
+        // No positive-area overlap, so the cover does not hide any part of this piece.
+        if (minPlaneX >= maxPlaneX || minPlaneY >= maxPlaneY) {
+            result.add(piece);
+            return false;
+        }
+
+        // Visible strip before the cover on the plane's Y axis.
+        if (piece.minPlaneY < minPlaneY) {
+            result.add(new FacePiece(piece.minPlaneX, piece.maxPlaneX, piece.minPlaneY, minPlaneY));
+        }
+        // Visible strip after the cover on the plane's Y axis.
+        if (piece.maxPlaneY > maxPlaneY) {
+            result.add(new FacePiece(piece.minPlaneX, piece.maxPlaneX, maxPlaneY, piece.maxPlaneY));
+        }
+        // Visible strip before the cover on the plane's X axis, limited to the cover's Y span.
+        if (piece.minPlaneX < minPlaneX) {
+            result.add(new FacePiece(piece.minPlaneX, minPlaneX, minPlaneY, maxPlaneY));
+        }
+        // Visible strip after the cover on the plane's X axis, limited to the cover's Y span.
+        if (piece.maxPlaneX > maxPlaneX) {
+            result.add(new FacePiece(maxPlaneX, piece.maxPlaneX, minPlaneY, maxPlaneY));
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/creativemd/littletiles/client/render/FaceClipper.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/FaceClipper.java
@@ -33,7 +33,7 @@ public class FaceClipper implements IFaceClipper {
     }
 
     /** Marks the given area of a side as hidden, in the axes spanning that side's plane. */
-    public void cover(ForgeDirection side, int minPlaneX, int minPlaneY, int maxPlaneX, int maxPlaneY) {
+    public void cover(ForgeDirection side, int minPlaneX, int maxPlaneX, int minPlaneY, int maxPlaneY) {
         List<FacePiece> sideCovers = covers[side.ordinal()];
         if (sideCovers == null) {
             sideCovers = new ArrayList<>();

--- a/src/main/java/com/creativemd/littletiles/client/render/FaceClipper.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/FaceClipper.java
@@ -23,6 +23,9 @@ public class FaceClipper implements IFaceClipper {
     @SuppressWarnings("unchecked")
     private final List<FacePiece>[] covers = new List[6];
 
+    /** Sides hidden as a whole, which no rectangular cover can express because the face is not a rectangle. */
+    private final boolean[] culled = new boolean[6];
+
     public FaceClipper(LittleTilesCubeObject cube) {
         this.minX = cube.gridMinX;
         this.minY = cube.gridMinY;
@@ -40,6 +43,15 @@ public class FaceClipper implements IFaceClipper {
             covers[side.ordinal()] = sideCovers;
         }
         sideCovers.add(new FacePiece(minPlaneX, maxPlaneX, minPlaneY, maxPlaneY));
+    }
+
+    /** Marks a whole side as hidden, for faces that are not rectangular. */
+    public void cullSide(ForgeDirection side) {
+        culled[side.ordinal()] = true;
+    }
+
+    public boolean isSideCulled(ForgeDirection side) {
+        return culled[side.ordinal()];
     }
 
     @Override

--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
@@ -20,7 +20,6 @@ import org.lwjgl.opengl.GL11;
 
 import com.creativemd.creativecore.client.block.IBlockAccessFake;
 import com.creativemd.creativecore.client.rendering.ExtendedRenderBlocks;
-import com.creativemd.creativecore.client.rendering.IFaceClipper;
 import com.creativemd.creativecore.common.utils.ColorUtils;
 import com.creativemd.creativecore.common.utils.CubeObject;
 import com.creativemd.creativecore.lib.Vector3d;
@@ -74,7 +73,7 @@ public class LittleTilesBlockRenderHelper {
     }
 
     private static boolean renderCutout(int x, int y, int z, LittleTilesCubeObject cube, IBlockAccess world,
-            ExtendedRenderBlocks renderer) {
+            ExtendedRenderBlocks renderer, FaceClipper faceClipper) {
         Mesh3d mesh = Mesh3dUtil.createMesh(
                 x,
                 y,
@@ -93,18 +92,19 @@ public class LittleTilesBlockRenderHelper {
         int brightness = cube.block.getMixedBrightnessForBlock(world, x, y, z);
         tess.setBrightness(brightness);
 
-        IFaceClipper faceClipper = renderer.faceClipper;
         Set<ForgeDirection> clippedSides = EnumSet.noneOf(ForgeDirection.class);
-        boolean rendered = false;
         for (Triangle3d triangle : mesh.getTriangles()) {
             if (faceClipper != null) {
                 ForgeDirection side = Plane3d.getPlaneForTriangle(triangle).getDirection();
+                // A culled side is hidden as a whole, so its triangles simply go away
+                if (faceClipper.isSideCulled(side)) {
+                    continue;
+                }
                 if (LittleTilesFaceCuller.hasUncutSolidSide(cube, side) && faceClipper.getFacePieces(side) != null) {
                     clippedSides.add(side);
                     continue;
                 }
             }
-            rendered = true;
             Vector3d p1 = triangle.getP1();
             Vector3d p2 = triangle.getP2();
             Vector3d p3 = triangle.getP3();
@@ -118,10 +118,10 @@ public class LittleTilesBlockRenderHelper {
             tess.addVertexWithUV(p3.x, p3.y, p3.z, tex3.x, tex3.y);
         }
         for (ForgeDirection side : clippedSides) {
-            rendered = true;
             renderMeshSide(renderer, cube, side, x, y, z);
         }
-        return rendered;
+        // An empty mesh means the shape could not be built, only then the plain box is the better fallback
+        return !mesh.getTriangles().isEmpty();
     }
 
     /** Reproduces a flat mesh side as the equivalent box quad, allowing ExtendedRenderBlocks to cut it into pieces. */
@@ -151,7 +151,7 @@ public class LittleTilesBlockRenderHelper {
         int pass = ForgeHooksClient.getWorldRenderPass();
         boolean rendered = false;
 
-        IFaceClipper[] coverage = LittleTilesFaceCuller.computeCoverage(world, cubes, x, y, z);
+        FaceClipper[] coverage = LittleTilesFaceCuller.computeCoverage(world, cubes, x, y, z);
 
         try {
             for (int i = 0; i < cubes.size(); i++) {
@@ -162,13 +162,14 @@ public class LittleTilesBlockRenderHelper {
                 rendered = true;
 
                 if (cube.cutoutInfo != null) {
-                    extraRenderer.faceClipper = null;
+                    FaceClipper faceClipper = null;
                     if (!cube.block.isOpaqueCube()) {
                         extraRenderer.clearOverrideBlockTexture();
                         extraRenderer.setRenderBounds(cube.minX, cube.minY, cube.minZ, cube.maxX, cube.maxY, cube.maxZ);
-                        extraRenderer.faceClipper = coverage[i];
+                        faceClipper = coverage[i];
                     }
-                    if (renderCutout(x, y, z, cube, world, extraRenderer)) {
+                    extraRenderer.faceClipper = faceClipper;
+                    if (renderCutout(x, y, z, cube, world, extraRenderer, faceClipper)) {
                         continue;
                     }
                     // For buggy meshes, render the default cube

--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
@@ -1,12 +1,15 @@
 package com.creativemd.littletiles.client.render;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.Set;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockAir;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.init.Blocks;
+import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -24,6 +27,7 @@ import com.creativemd.creativecore.lib.Vector3d;
 import com.creativemd.littletiles.LittleTiles;
 import com.creativemd.littletiles.client.util3d.Mesh3d;
 import com.creativemd.littletiles.client.util3d.Mesh3dUtil;
+import com.creativemd.littletiles.client.util3d.Plane3d;
 import com.creativemd.littletiles.client.util3d.Triangle3d;
 import com.creativemd.littletiles.common.utils.LittleTileCutoutInfo;
 import com.creativemd.littletiles.common.utils.LittleTileShapeMode;
@@ -69,7 +73,8 @@ public class LittleTilesBlockRenderHelper {
         GL11.glPopMatrix();
     }
 
-    private static boolean renderCutout(int x, int y, int z, LittleTilesCubeObject cube, IBlockAccess world) {
+    private static boolean renderCutout(int x, int y, int z, LittleTilesCubeObject cube, IBlockAccess world,
+            ExtendedRenderBlocks renderer) {
         Mesh3d mesh = Mesh3dUtil.createMesh(
                 x,
                 y,
@@ -87,7 +92,19 @@ public class LittleTilesBlockRenderHelper {
 
         int brightness = cube.block.getMixedBrightnessForBlock(world, x, y, z);
         tess.setBrightness(brightness);
+
+        IFaceClipper faceClipper = renderer.faceClipper;
+        Set<ForgeDirection> clippedSides = EnumSet.noneOf(ForgeDirection.class);
+        boolean rendered = false;
         for (Triangle3d triangle : mesh.getTriangles()) {
+            if (faceClipper != null) {
+                ForgeDirection side = Plane3d.getPlaneForTriangle(triangle).getDirection();
+                if (LittleTilesFaceCuller.hasUncutSolidSide(cube, side) && faceClipper.getFacePieces(side) != null) {
+                    clippedSides.add(side);
+                    continue;
+                }
+            }
+            rendered = true;
             Vector3d p1 = triangle.getP1();
             Vector3d p2 = triangle.getP2();
             Vector3d p3 = triangle.getP3();
@@ -100,7 +117,26 @@ public class LittleTilesBlockRenderHelper {
             tess.addVertexWithUV(p3.x, p3.y, p3.z, tex3.x, tex3.y);
             tess.addVertexWithUV(p3.x, p3.y, p3.z, tex3.x, tex3.y);
         }
-        return !mesh.getTriangles().isEmpty();
+        for (ForgeDirection side : clippedSides) {
+            rendered = true;
+            renderMeshSide(renderer, cube, side, x, y, z);
+        }
+        return rendered;
+    }
+
+    /** Reproduces a flat mesh side as the equivalent box quad, allowing ExtendedRenderBlocks to cut it into pieces. */
+    private static void renderMeshSide(ExtendedRenderBlocks renderer, LittleTilesCubeObject cube, ForgeDirection side,
+            int x, int y, int z) {
+        IIcon icon = cube.block.getIcon(side.ordinal(), cube.meta);
+        switch (side) {
+            case DOWN -> renderer.renderFaceYNeg(cube.block, x, y, z, icon);
+            case UP -> renderer.renderFaceYPos(cube.block, x, y, z, icon);
+            case NORTH -> renderer.renderFaceZNeg(cube.block, x, y, z, icon);
+            case SOUTH -> renderer.renderFaceZPos(cube.block, x, y, z, icon);
+            case WEST -> renderer.renderFaceXNeg(cube.block, x, y, z, icon);
+            case EAST -> renderer.renderFaceXPos(cube.block, x, y, z, icon);
+            default -> {}
+        }
     }
 
     public static boolean renderCubes(IBlockAccess world, ArrayList<LittleTilesCubeObject> cubes, int x, int y, int z,
@@ -126,7 +162,13 @@ public class LittleTilesBlockRenderHelper {
                 rendered = true;
 
                 if (cube.cutoutInfo != null) {
-                    if (renderCutout(x, y, z, cube, world)) {
+                    extraRenderer.faceClipper = null;
+                    if (!cube.block.isOpaqueCube()) {
+                        extraRenderer.clearOverrideBlockTexture();
+                        extraRenderer.setRenderBounds(cube.minX, cube.minY, cube.minZ, cube.maxX, cube.maxY, cube.maxZ);
+                        extraRenderer.faceClipper = coverage[i];
+                    }
+                    if (renderCutout(x, y, z, cube, world, extraRenderer)) {
                         continue;
                     }
                     // For buggy meshes, render the default cube

--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
@@ -115,7 +115,7 @@ public class LittleTilesBlockRenderHelper {
         int pass = ForgeHooksClient.getWorldRenderPass();
         boolean rendered = false;
 
-        IFaceClipper[] coverage = LittleTilesFaceCuller.computeCoverage(cubes);
+        IFaceClipper[] coverage = LittleTilesFaceCuller.computeCoverage(world, cubes, x, y, z);
 
         try {
             for (int i = 0; i < cubes.size(); i++) {

--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
@@ -17,6 +17,7 @@ import org.lwjgl.opengl.GL11;
 
 import com.creativemd.creativecore.client.block.IBlockAccessFake;
 import com.creativemd.creativecore.client.rendering.ExtendedRenderBlocks;
+import com.creativemd.creativecore.client.rendering.IFaceClipper;
 import com.creativemd.creativecore.common.utils.ColorUtils;
 import com.creativemd.creativecore.common.utils.CubeObject;
 import com.creativemd.creativecore.lib.Vector3d;
@@ -114,6 +115,8 @@ public class LittleTilesBlockRenderHelper {
         int pass = ForgeHooksClient.getWorldRenderPass();
         boolean rendered = false;
 
+        IFaceClipper[] coverage = LittleTilesFaceCuller.computeCoverage(cubes);
+
         try {
             for (int i = 0; i < cubes.size(); i++) {
                 final LittleTilesCubeObject cube = cubes.get(i);
@@ -135,6 +138,7 @@ public class LittleTilesBlockRenderHelper {
                     extraRenderer.meta = cube.meta;
                     fake.overrideMeta = cube.meta;
                     extraRenderer.color = cube.color;
+                    extraRenderer.faceClipper = coverage[i];
                     extraRenderer.lockBlockBounds = true;
                     if (LittleTiles.angelicaCompat != null) {
                         LittleTiles.angelicaCompat.setShaderMaterialOverride(cube.block, cube.meta);
@@ -150,6 +154,7 @@ public class LittleTilesBlockRenderHelper {
                 }
             }
         } finally {
+            extraRenderer.faceClipper = null;
             fake.world = null;
         }
         return rendered;

--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
@@ -1,0 +1,105 @@
+package com.creativemd.littletiles.client.render;
+
+import static com.creativemd.creativecore.common.utils.RotationUtils.Axis.AxisX;
+import static com.creativemd.creativecore.common.utils.RotationUtils.Axis.AxisY;
+import static com.creativemd.creativecore.common.utils.RotationUtils.Axis.AxisZ;
+
+import java.util.List;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+import com.creativemd.creativecore.client.rendering.IFaceClipper;
+import com.creativemd.creativecore.common.utils.RotationUtils;
+import com.creativemd.creativecore.common.utils.RotationUtils.Axis;
+import com.creativemd.littletiles.common.utils.LittleTilesCubeObject;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+/**
+ * Computes which parts of a tile entity's cube faces are covered by other cubes of the same tile entity.
+ * <p>
+ * Covered faces are split by {@link FaceClipper}; fully covered faces produce no pieces and therefore emit no quad.
+ */
+@SideOnly(Side.CLIENT)
+public final class LittleTilesFaceCuller {
+
+    /**
+     * The two axes spanning a side's plane, used as the local 2D axes for clipping rectangles on that face: DOWN/UP use
+     * X/Z, NORTH/SOUTH use X/Y, and WEST/EAST use Z/Y. The axis a side is perpendicular to comes from
+     * {@link Axis#getAxis(ForgeDirection)}.
+     * <p>
+     * Indexed by {@link ForgeDirection#ordinal()}: DOWN, UP, NORTH, SOUTH, WEST, EAST.
+     * <p>
+     * That in-plane orientation is a convention, not something Forge supplies. Swapping a face to Z/X or Y/Z would also
+     * be valid if FaceClipper and ExtendedRenderBlocks used the same convention.
+     */
+    private static final Axis[] PLANE_X_AXIS = { AxisX, AxisX, AxisX, AxisX, AxisZ, AxisZ };
+    private static final Axis[] PLANE_Y_AXIS = { AxisZ, AxisZ, AxisY, AxisY, AxisY, AxisY };
+
+    private LittleTilesFaceCuller() {}
+
+    /**
+     * Computes the covered areas of every cube of one tile entity, indexed like {@code cubes}.
+     * <p>
+     * Must be given all cubes, not just the ones of the current render pass: a tile drawn in pass 0 still hides the
+     * faces of a tile drawn in pass 1.
+     */
+    public static IFaceClipper[] computeCoverage(List<LittleTilesCubeObject> cubes) {
+        IFaceClipper[] clippers = new IFaceClipper[cubes.size()];
+        for (int i = 0; i < cubes.size(); i++) {
+            LittleTilesCubeObject cube = cubes.get(i);
+            if (ignoreForCulling(cube)) {
+                continue;
+            }
+            FaceClipper clipper = new FaceClipper(cube);
+            clippers[i] = clipper;
+            for (int j = 0; j < cubes.size(); j++) {
+                LittleTilesCubeObject occluder = cubes.get(j);
+                if (j != i && canOcclude(occluder, cube)) {
+                    cover(clipper, cube, occluder);
+                }
+            }
+        }
+        return clippers;
+    }
+
+    /**
+     * Invalid blocks have nothing to cull and cutouts are meshes rather than boxes. Clipping opaque blocks costs more
+     * CPU than the saved GPU work is worth.
+     */
+    private static boolean ignoreForCulling(LittleTilesCubeObject cube) {
+        return cube.block == null || cube.meta == -1 || cube.cutoutInfo != null || cube.block.isOpaqueCube();
+    }
+
+    private static boolean canOcclude(LittleTilesCubeObject occluder, LittleTilesCubeObject cube) {
+        if (ignoreForCulling(occluder)) {
+            return false;
+        }
+        // A translucent tile only hides an identical neighbour. Glass against stained glass is
+        // intentional layering and has to keep both faces.
+        return occluder.block == cube.block && occluder.meta == cube.meta && occluder.color == cube.color;
+    }
+
+    /** Marks the areas the given occluder covers on the faces of {@code cube} it sits flush against. */
+    private static void cover(FaceClipper clipper, LittleTilesCubeObject cube, LittleTilesCubeObject occluder) {
+        for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
+            Axis axis = Axis.getAxis(side);
+            boolean flush = RotationUtils.isNegative(side) ? occluder.gridMax(axis) == cube.gridMin(axis)
+                    : occluder.gridMin(axis) == cube.gridMax(axis);
+            if (!flush) {
+                continue;
+            }
+
+            Axis planeX = PLANE_X_AXIS[side.ordinal()];
+            Axis planeY = PLANE_Y_AXIS[side.ordinal()];
+            int minPlaneX = Math.max(cube.gridMin(planeX), occluder.gridMin(planeX));
+            int maxPlaneX = Math.min(cube.gridMax(planeX), occluder.gridMax(planeX));
+            int minPlaneY = Math.max(cube.gridMin(planeY), occluder.gridMin(planeY));
+            int maxPlaneY = Math.min(cube.gridMax(planeY), occluder.gridMax(planeY));
+            if (minPlaneX < maxPlaneX && minPlaneY < maxPlaneY) {
+                clipper.cover(side, minPlaneX, minPlaneY, maxPlaneX, maxPlaneY);
+            }
+        }
+    }
+}

--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
@@ -4,20 +4,26 @@ import static com.creativemd.creativecore.common.utils.RotationUtils.Axis.AxisX;
 import static com.creativemd.creativecore.common.utils.RotationUtils.Axis.AxisY;
 import static com.creativemd.creativecore.common.utils.RotationUtils.Axis.AxisZ;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.creativemd.creativecore.client.rendering.IFaceClipper;
 import com.creativemd.creativecore.common.utils.RotationUtils;
 import com.creativemd.creativecore.common.utils.RotationUtils.Axis;
+import com.creativemd.littletiles.common.tileentity.TileEntityLittleTiles;
+import com.creativemd.littletiles.common.utils.LittleTile;
 import com.creativemd.littletiles.common.utils.LittleTilesCubeObject;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 /**
- * Computes which parts of a tile entity's cube faces are covered by other cubes of the same tile entity.
+ * Computes which parts of a tile entity's cube faces are covered by other cubes in the same or adjacent tile entities.
  * <p>
  * Covered faces are split by {@link FaceClipper}; fully covered faces produce no pieces and therefore emit no quad.
  */
@@ -40,13 +46,18 @@ public final class LittleTilesFaceCuller {
     private LittleTilesFaceCuller() {}
 
     /**
-     * Computes the covered areas of every cube of one tile entity, indexed like {@code cubes}.
+     * Computes the covered areas of every cube of the tile entity at the given position. Cubes that are never clipped
+     * get a null entry, which renders them untouched.
+     * <p>
+     * Cubes reaching a block boundary are additionally clipped against the adjacent {@link TileEntityLittleTiles}, if
+     * there is one.
      * <p>
      * Must be given all cubes, not just the ones of the current render pass: a tile drawn in pass 0 still hides the
      * faces of a tile drawn in pass 1.
      */
-    public static IFaceClipper[] computeCoverage(List<LittleTilesCubeObject> cubes) {
-        IFaceClipper[] clippers = new IFaceClipper[cubes.size()];
+    public static IFaceClipper[] computeCoverage(IBlockAccess world, List<LittleTilesCubeObject> cubes, int x, int y,
+            int z) {
+        FaceClipper[] clippers = new FaceClipper[cubes.size()];
         for (int i = 0; i < cubes.size(); i++) {
             LittleTilesCubeObject cube = cubes.get(i);
             if (ignoreForCulling(cube)) {
@@ -61,7 +72,72 @@ public final class LittleTilesFaceCuller {
                 }
             }
         }
+        coverNeighbours(world, cubes, clippers, x, y, z);
         return clippers;
+    }
+
+    /** Whether the cube is flush against the edge of its own block on the given side. */
+    private static boolean touchesBorder(LittleTilesCubeObject cube, ForgeDirection side) {
+        Axis axis = Axis.getAxis(side);
+        return RotationUtils.isNegative(side) ? cube.gridMin(axis) == 0 : cube.gridMax(axis) == 16;
+    }
+
+    private static void coverNeighbours(IBlockAccess world, List<LittleTilesCubeObject> cubes, FaceClipper[] clippers,
+            int x, int y, int z) {
+        for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
+            List<LittleTilesCubeObject> neighbourCubes = null;
+            for (int i = 0; i < cubes.size(); i++) {
+                LittleTilesCubeObject cube = cubes.get(i);
+                if (clippers[i] == null || !touchesBorder(cube, side)) {
+                    continue;
+                }
+                if (neighbourCubes == null) {
+                    neighbourCubes = getNeighbourBorderCubes(
+                            world,
+                            x + side.offsetX,
+                            y + side.offsetY,
+                            z + side.offsetZ,
+                            side.getOpposite());
+                    if (neighbourCubes.isEmpty()) {
+                        break;
+                    }
+                }
+                for (LittleTilesCubeObject occluder : neighbourCubes) {
+                    if (canOcclude(occluder, cube)) {
+                        coverSide(clippers[i], cube, occluder, side);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * The cubes of the tile entity at the given position that reach its {@code border} side, which is the side facing
+     * back at us and therefore the only one that can occlude anything of ours.
+     */
+    private static List<LittleTilesCubeObject> getNeighbourBorderCubes(IBlockAccess world, int x, int y, int z,
+            ForgeDirection border) {
+        TileEntity tileEntity = world.getTileEntity(x, y, z);
+        if (!(tileEntity instanceof TileEntityLittleTiles)) {
+            return Collections.emptyList();
+        }
+
+        TileEntityLittleTiles little = (TileEntityLittleTiles) tileEntity;
+        List<LittleTile> tiles = little.getTiles();
+        List<LittleTile> snapshot;
+        synchronized (tiles) {
+            snapshot = new ArrayList<>(tiles);
+        }
+
+        ArrayList<LittleTilesCubeObject> cubes = new ArrayList<>();
+        for (LittleTile tile : snapshot) {
+            for (LittleTilesCubeObject cube : tile.getRenderingCubes()) {
+                if (!ignoreForCulling(cube) && touchesBorder(cube, border)) {
+                    cubes.add(cube);
+                }
+            }
+        }
+        return cubes;
     }
 
     /**
@@ -72,6 +148,10 @@ public final class LittleTilesFaceCuller {
         return cube.block == null || cube.meta == -1 || cube.cutoutInfo != null || cube.block.isOpaqueCube();
     }
 
+    /*
+     * We only care about occlusion between transparent/translucent blocks of the same type - there we need to cull.
+     * Opaque blocks are ignored here.
+     */
     private static boolean canOcclude(LittleTilesCubeObject occluder, LittleTilesCubeObject cube) {
         if (ignoreForCulling(occluder)) {
             return false;
@@ -91,15 +171,20 @@ public final class LittleTilesFaceCuller {
                 continue;
             }
 
-            Axis planeX = PLANE_X_AXIS[side.ordinal()];
-            Axis planeY = PLANE_Y_AXIS[side.ordinal()];
-            int minPlaneX = Math.max(cube.gridMin(planeX), occluder.gridMin(planeX));
-            int maxPlaneX = Math.min(cube.gridMax(planeX), occluder.gridMax(planeX));
-            int minPlaneY = Math.max(cube.gridMin(planeY), occluder.gridMin(planeY));
-            int maxPlaneY = Math.min(cube.gridMax(planeY), occluder.gridMax(planeY));
-            if (minPlaneX < maxPlaneX && minPlaneY < maxPlaneY) {
-                clipper.cover(side, minPlaneX, minPlaneY, maxPlaneX, maxPlaneY);
-            }
+            coverSide(clipper, cube, occluder, side);
+        }
+    }
+
+    private static void coverSide(FaceClipper clipper, LittleTilesCubeObject cube, LittleTilesCubeObject occluder,
+            ForgeDirection side) {
+        Axis planeX = PLANE_X_AXIS[side.ordinal()];
+        Axis planeY = PLANE_Y_AXIS[side.ordinal()];
+        int minPlaneX = Math.max(cube.gridMin(planeX), occluder.gridMin(planeX));
+        int maxPlaneX = Math.min(cube.gridMax(planeX), occluder.gridMax(planeX));
+        int minPlaneY = Math.max(cube.gridMin(planeY), occluder.gridMin(planeY));
+        int maxPlaneY = Math.min(cube.gridMax(planeY), occluder.gridMax(planeY));
+        if (minPlaneX < maxPlaneX && minPlaneY < maxPlaneY) {
+            clipper.cover(side, minPlaneX, minPlaneY, maxPlaneX, maxPlaneY);
         }
     }
 }

--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
@@ -12,9 +12,15 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import org.joml.Matrix3f;
+import org.joml.Vector3f;
+import org.joml.Vector3i;
+
 import com.creativemd.creativecore.client.rendering.IFaceClipper;
 import com.creativemd.creativecore.common.utils.RotationUtils;
 import com.creativemd.creativecore.common.utils.RotationUtils.Axis;
+import com.creativemd.littletiles.client.util3d.Mesh3dUtil;
+import com.creativemd.littletiles.client.util3d.OrientationMapper;
 import com.creativemd.littletiles.common.tileentity.TileEntityLittleTiles;
 import com.creativemd.littletiles.common.utils.LittleTile;
 import com.creativemd.littletiles.common.utils.LittleTilesCubeObject;
@@ -82,6 +88,52 @@ public final class LittleTilesFaceCuller {
         return RotationUtils.isNegative(side) ? cube.gridMin(axis) == 0 : cube.gridMax(axis) == 16;
     }
 
+    private static boolean hasUncutSolidSide(LittleTilesCubeObject cube, ForgeDirection side) {
+        if (cube.cutoutInfo == null) {
+            return true;
+        }
+
+        boolean[] solidSides = Mesh3dUtil.getSolidSides(cube.cutoutInfo.type);
+        for (ForgeDirection baseSide : ForgeDirection.VALID_DIRECTIONS) {
+            if (solidSides[baseSide.ordinal()] && rotate(baseSide, cube.cutoutInfo.orientation) == side
+                    && !isSideCut(cube, side)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Whether clipping the complete cutout mesh to this little-tile box introduced the given side. Such a side is flat,
+     * but it is not one of the shape's original solid sides and must not occlude a neighbouring box.
+     */
+    private static boolean isSideCut(LittleTilesCubeObject cube, ForgeDirection side) {
+        Axis axis = Axis.getAxis(side);
+        // Mesh3dUtil places the mesh at the cutout offset relative to the box and then clips it to the box, so the
+        // mesh sticking out on a side is the case there it got cut
+        int meshMin = cube.gridMin(axis) + component(cube.cutoutInfo.pos, axis);
+        int meshMax = meshMin + component(cube.cutoutInfo.size, axis);
+        return RotationUtils.isNegative(side) ? meshMin < cube.gridMin(axis) : meshMax > cube.gridMax(axis);
+    }
+
+    private static int component(Vector3i vector, Axis axis) {
+        return axis == AxisX ? vector.x : (axis == AxisY ? vector.y : vector.z);
+    }
+
+    private static ForgeDirection rotate(ForgeDirection side, int orientation) {
+        Matrix3f matrix = OrientationMapper.fromId(orientation);
+        Vector3f rotated = matrix.transform(new Vector3f(side.offsetX, side.offsetY, side.offsetZ));
+        int x = Math.round(rotated.x);
+        int y = Math.round(rotated.y);
+        int z = Math.round(rotated.z);
+        for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
+            if (direction.offsetX == x && direction.offsetY == y && direction.offsetZ == z) {
+                return direction;
+            }
+        }
+        return ForgeDirection.UNKNOWN;
+    }
+
     private static void coverNeighbours(IBlockAccess world, List<LittleTilesCubeObject> cubes, FaceClipper[] clippers,
             int x, int y, int z) {
         for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
@@ -103,7 +155,7 @@ public final class LittleTilesFaceCuller {
                     }
                 }
                 for (LittleTilesCubeObject occluder : neighbourCubes) {
-                    if (canOcclude(occluder, cube)) {
+                    if (canOcclude(occluder, cube) && hasUncutSolidSide(occluder, side.getOpposite())) {
                         coverSide(clippers[i], cube, occluder, side);
                     }
                 }
@@ -132,7 +184,7 @@ public final class LittleTilesFaceCuller {
         ArrayList<LittleTilesCubeObject> cubes = new ArrayList<>();
         for (LittleTile tile : snapshot) {
             for (LittleTilesCubeObject cube : tile.getRenderingCubes()) {
-                if (!ignoreForCulling(cube) && touchesBorder(cube, border)) {
+                if (!ignoreForCulling(cube) && touchesBorder(cube, border) && hasUncutSolidSide(cube, border)) {
                     cubes.add(cube);
                 }
             }
@@ -141,11 +193,10 @@ public final class LittleTilesFaceCuller {
     }
 
     /**
-     * Invalid blocks have nothing to cull and cutouts are meshes rather than boxes. Clipping opaque blocks costs more
-     * CPU than the saved GPU work is worth.
+     * Invalid blocks have nothing to cull. Clipping opaque blocks costs more CPU than the saved GPU work is worth.
      */
     private static boolean ignoreForCulling(LittleTilesCubeObject cube) {
-        return cube.block == null || cube.meta == -1 || cube.cutoutInfo != null || cube.block.isOpaqueCube();
+        return cube.block == null || cube.meta == -1 || cube.block.isOpaqueCube();
     }
 
     /*
@@ -167,7 +218,7 @@ public final class LittleTilesFaceCuller {
             Axis axis = Axis.getAxis(side);
             boolean flush = RotationUtils.isNegative(side) ? occluder.gridMax(axis) == cube.gridMin(axis)
                     : occluder.gridMin(axis) == cube.gridMax(axis);
-            if (!flush) {
+            if (!flush || !hasUncutSolidSide(occluder, side.getOpposite())) {
                 continue;
             }
             coverSide(clipper, cube, occluder, side);

--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
@@ -114,29 +114,70 @@ public final class LittleTilesFaceCuller {
     }
 
     /**
-     * Whether the two meshes meet end to end with the very same cross-section, so that each hides the other's face on
-     * {@code side} completely. That needs the same shape and orientation, both facing each other with an uncut
-     * cross-section.
+     * Whether the two meshes meet with the very same cross-section, so that each hides the other's face on
+     * {@code side} completely. This covers both repeating prisms and pieces clipped from one source mesh.
      */
-    private static boolean isMatchingPrismSide(LittleTilesCubeObject cube, LittleTilesCubeObject occluder,
-            ForgeDirection side) {
+    private static boolean isMatchingMeshSide(LittleTilesCubeObject cube, LittleTilesCubeObject occluder,
+            ForgeDirection side, int occluderOffsetX, int occluderOffsetY, int occluderOffsetZ) {
         if (cube.cutoutInfo == null || occluder.cutoutInfo == null
                 || cube.cutoutInfo.type != occluder.cutoutInfo.type
                 || cube.cutoutInfo.orientation != occluder.cutoutInfo.orientation) {
             return false;
         }
-        if (!hasUncutPrismSide(cube, side) || !hasUncutPrismSide(occluder, side.getOpposite())) {
+
+        boolean alignedFace = isAlignedOnAxis(
+                        cube, occluder, PLANE_X_AXIS[side.ordinal()], occluderOffsetX, occluderOffsetY, occluderOffsetZ)
+                && isAlignedOnAxis(
+                        cube, occluder, PLANE_Y_AXIS[side.ordinal()], occluderOffsetX, occluderOffsetY, occluderOffsetZ);
+        if (!alignedFace) {
             return false;
         }
-        return isAlignedOnAxis(cube, occluder, PLANE_X_AXIS[side.ordinal()])
-                && isAlignedOnAxis(cube, occluder, PLANE_Y_AXIS[side.ordinal()]);
+
+        // Identical prisms can repeat end to end.
+        if (hasUncutPrismSide(cube, side) && hasUncutPrismSide(occluder, side.getOpposite())) {
+            return true;
+        }
+
+        // A tile can be divided either inside one block or at a block boundary. In that case both pieces still carry
+        // the complete source mesh, translated relative to their respective boxes. Reconstructing that source origin
+        // lets us recognize the two generated cut faces as the same cross-section of one continuous mesh.
+        return isClippedAtSide(cube, side)
+                && isClippedAtSide(occluder, side.getOpposite())
+                && hasSameSourceMesh(
+                        cube, occluder, occluderOffsetX, occluderOffsetY, occluderOffsetZ);
     }
 
     /** Whether both the boxes and the meshes inside them span the exact same range on the given axis. */
-    private static boolean isAlignedOnAxis(LittleTilesCubeObject cube, LittleTilesCubeObject occluder, Axis axis) {
-        return cube.gridMin(axis) == occluder.gridMin(axis) && cube.gridMax(axis) == occluder.gridMax(axis)
+    private static boolean isAlignedOnAxis(LittleTilesCubeObject cube, LittleTilesCubeObject occluder, Axis axis,
+            int occluderOffsetX, int occluderOffsetY, int occluderOffsetZ) {
+        int offset = component(occluderOffsetX, occluderOffsetY, occluderOffsetZ, axis);
+        return cube.gridMin(axis) == occluder.gridMin(axis) + offset
+                && cube.gridMax(axis) == occluder.gridMax(axis) + offset
                 && component(cube.cutoutInfo.pos, axis) == component(occluder.cutoutInfo.pos, axis)
                 && component(cube.cutoutInfo.size, axis) == component(occluder.cutoutInfo.size, axis);
+    }
+
+    private static boolean hasSameSourceMesh(LittleTilesCubeObject cube, LittleTilesCubeObject occluder,
+            int occluderOffsetX, int occluderOffsetY, int occluderOffsetZ) {
+        for (Axis axis : Axis.values()) {
+            int occluderOffset = component(occluderOffsetX, occluderOffsetY, occluderOffsetZ, axis);
+            int cubeOrigin = cube.gridMin(axis) + component(cube.cutoutInfo.pos, axis);
+            int occluderOrigin =
+                    occluder.gridMin(axis) + component(occluder.cutoutInfo.pos, axis) + occluderOffset;
+            if (cubeOrigin != occluderOrigin
+                    || component(cube.cutoutInfo.size, axis) != component(occluder.cutoutInfo.size, axis)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** Whether clipping the source mesh to this tile box generated a face on this side. */
+    private static boolean isClippedAtSide(LittleTilesCubeObject cube, ForgeDirection side) {
+        Axis axis = Axis.getAxis(side);
+        int meshMin = cube.gridMin(axis) + component(cube.cutoutInfo.pos, axis);
+        int meshMax = meshMin + component(cube.cutoutInfo.size, axis);
+        return RotationUtils.isNegative(side) ? meshMin < cube.gridMin(axis) : meshMax > cube.gridMax(axis);
     }
 
     /**
@@ -154,6 +195,10 @@ public final class LittleTilesFaceCuller {
 
     private static int component(Vector3i vector, Axis axis) {
         return axis == AxisX ? vector.x : (axis == AxisY ? vector.y : vector.z);
+    }
+
+    private static int component(int x, int y, int z, Axis axis) {
+        return axis == AxisX ? x : (axis == AxisY ? y : z);
     }
 
     private static ForgeDirection rotate(ForgeDirection side, int orientation) {
@@ -192,7 +237,14 @@ public final class LittleTilesFaceCuller {
                 }
                 for (LittleTilesCubeObject occluder : neighbourCubes) {
                     if (canOcclude(occluder, cube)) {
-                        coverFlushSide(clippers[i], cube, occluder, side);
+                        coverFlushSide(
+                                clippers[i],
+                                cube,
+                                occluder,
+                                side,
+                                side.offsetX * 16,
+                                side.offsetY * 16,
+                                side.offsetZ * 16);
                     }
                 }
             }
@@ -221,7 +273,9 @@ public final class LittleTilesFaceCuller {
         for (LittleTile tile : snapshot) {
             for (LittleTilesCubeObject cube : tile.getRenderingCubes()) {
                 if (!ignoreForCulling(cube) && touchesBorder(cube, border)
-                        && (hasUncutSolidSide(cube, border) || hasUncutPrismSide(cube, border))) {
+                        && (hasUncutSolidSide(cube, border)
+                                || hasUncutPrismSide(cube, border)
+                                || (cube.cutoutInfo != null && isClippedAtSide(cube, border)))) {
                     cubes.add(cube);
                 }
             }
@@ -256,7 +310,7 @@ public final class LittleTilesFaceCuller {
             boolean flush = RotationUtils.isNegative(side) ? occluder.gridMax(axis) == cube.gridMin(axis)
                     : occluder.gridMin(axis) == cube.gridMax(axis);
             if (flush) {
-                coverFlushSide(clipper, cube, occluder, side);
+                coverFlushSide(clipper, cube, occluder, side, 0, 0, 0);
             }
         }
     }
@@ -266,10 +320,11 @@ public final class LittleTilesFaceCuller {
      * the box face, or, for two meshes meeting end to end, the whole face.
      */
     private static void coverFlushSide(FaceClipper clipper, LittleTilesCubeObject cube, LittleTilesCubeObject occluder,
-            ForgeDirection side) {
+            ForgeDirection side, int occluderOffsetX, int occluderOffsetY, int occluderOffsetZ) {
         if (hasUncutSolidSide(occluder, side.getOpposite())) {
             coverSide(clipper, cube, occluder, side);
-        } else if (isMatchingPrismSide(cube, occluder, side)) {
+        } else if (isMatchingMeshSide(
+                cube, occluder, side, occluderOffsetX, occluderOffsetY, occluderOffsetZ)) {
             clipper.cullSide(side);
         }
     }

--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
@@ -170,7 +170,6 @@ public final class LittleTilesFaceCuller {
             if (!flush) {
                 continue;
             }
-
             coverSide(clipper, cube, occluder, side);
         }
     }
@@ -184,7 +183,7 @@ public final class LittleTilesFaceCuller {
         int minPlaneY = Math.max(cube.gridMin(planeY), occluder.gridMin(planeY));
         int maxPlaneY = Math.min(cube.gridMax(planeY), occluder.gridMax(planeY));
         if (minPlaneX < maxPlaneX && minPlaneY < maxPlaneY) {
-            clipper.cover(side, minPlaneX, minPlaneY, maxPlaneX, maxPlaneY);
+            clipper.cover(side, minPlaneX, maxPlaneX, minPlaneY, maxPlaneY);
         }
     }
 }

--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
@@ -16,7 +16,6 @@ import org.joml.Matrix3f;
 import org.joml.Vector3f;
 import org.joml.Vector3i;
 
-import com.creativemd.creativecore.client.rendering.IFaceClipper;
 import com.creativemd.creativecore.common.utils.RotationUtils;
 import com.creativemd.creativecore.common.utils.RotationUtils.Axis;
 import com.creativemd.littletiles.client.util3d.Mesh3dUtil;
@@ -61,7 +60,7 @@ public final class LittleTilesFaceCuller {
      * Must be given all cubes, not just the ones of the current render pass: a tile drawn in pass 0 still hides the
      * faces of a tile drawn in pass 1.
      */
-    public static IFaceClipper[] computeCoverage(IBlockAccess world, List<LittleTilesCubeObject> cubes, int x, int y,
+    public static FaceClipper[] computeCoverage(IBlockAccess world, List<LittleTilesCubeObject> cubes, int x, int y,
             int z) {
         FaceClipper[] clippers = new FaceClipper[cubes.size()];
         for (int i = 0; i < cubes.size(); i++) {
@@ -92,10 +91,21 @@ public final class LittleTilesFaceCuller {
         if (cube.cutoutInfo == null) {
             return true;
         }
+        return hasUncutMeshSide(cube, side, Mesh3dUtil.getSolidSides(cube.cutoutInfo.type));
+    }
 
-        boolean[] solidSides = Mesh3dUtil.getSolidSides(cube.cutoutInfo.type);
+    /** Whether this side of the mesh is one of the shape's cross-sections, see {@link Mesh3dUtil#getPrismSides}. */
+    private static boolean hasUncutPrismSide(LittleTilesCubeObject cube, ForgeDirection side) {
+        if (cube.cutoutInfo == null) {
+            return false;
+        }
+        return hasUncutMeshSide(cube, side, Mesh3dUtil.getPrismSides(cube.cutoutInfo.type));
+    }
+
+    /** Whether one of the given sides of the shape ends up on {@code side} and survived the clipping to the box. */
+    private static boolean hasUncutMeshSide(LittleTilesCubeObject cube, ForgeDirection side, boolean[] baseSides) {
         for (ForgeDirection baseSide : ForgeDirection.VALID_DIRECTIONS) {
-            if (solidSides[baseSide.ordinal()] && rotate(baseSide, cube.cutoutInfo.orientation) == side
+            if (baseSides[baseSide.ordinal()] && rotate(baseSide, cube.cutoutInfo.orientation) == side
                     && !isSideCut(cube, side)) {
                 return true;
             }
@@ -104,16 +114,42 @@ public final class LittleTilesFaceCuller {
     }
 
     /**
-     * Whether clipping the complete cutout mesh to this little-tile box introduced the given side. Such a side is flat,
-     * but it is not one of the shape's original solid sides and must not occlude a neighbouring box.
+     * Whether the two meshes meet end to end with the very same cross-section, so that each hides the other's face on
+     * {@code side} completely. That needs the same shape and orientation, both facing each other with an uncut
+     * cross-section.
+     */
+    private static boolean isMatchingPrismSide(LittleTilesCubeObject cube, LittleTilesCubeObject occluder,
+            ForgeDirection side) {
+        if (cube.cutoutInfo == null || occluder.cutoutInfo == null
+                || cube.cutoutInfo.type != occluder.cutoutInfo.type
+                || cube.cutoutInfo.orientation != occluder.cutoutInfo.orientation) {
+            return false;
+        }
+        if (!hasUncutPrismSide(cube, side) || !hasUncutPrismSide(occluder, side.getOpposite())) {
+            return false;
+        }
+        return isAlignedOnAxis(cube, occluder, PLANE_X_AXIS[side.ordinal()])
+                && isAlignedOnAxis(cube, occluder, PLANE_Y_AXIS[side.ordinal()]);
+    }
+
+    /** Whether both the boxes and the meshes inside them span the exact same range on the given axis. */
+    private static boolean isAlignedOnAxis(LittleTilesCubeObject cube, LittleTilesCubeObject occluder, Axis axis) {
+        return cube.gridMin(axis) == occluder.gridMin(axis) && cube.gridMax(axis) == occluder.gridMax(axis)
+                && component(cube.cutoutInfo.pos, axis) == component(occluder.cutoutInfo.pos, axis)
+                && component(cube.cutoutInfo.size, axis) == component(occluder.cutoutInfo.size, axis);
+    }
+
+    /**
+     * Whether the shape's face on the given side did not survive the clipping to this little-tile box, so that the box
+     * side is not covered by it. Mesh3dUtil places the mesh at the cutout offset relative to the box and then clips it
+     * to the box, so the face is only left intact if the mesh ends exactly on the box side: sticking out means it got
+     * cut off, ending short means the face is somewhere inside the box instead of on its side.
      */
     private static boolean isSideCut(LittleTilesCubeObject cube, ForgeDirection side) {
         Axis axis = Axis.getAxis(side);
-        // Mesh3dUtil places the mesh at the cutout offset relative to the box and then clips it to the box, so the
-        // mesh sticking out on a side is the case there it got cut
         int meshMin = cube.gridMin(axis) + component(cube.cutoutInfo.pos, axis);
         int meshMax = meshMin + component(cube.cutoutInfo.size, axis);
-        return RotationUtils.isNegative(side) ? meshMin < cube.gridMin(axis) : meshMax > cube.gridMax(axis);
+        return RotationUtils.isNegative(side) ? meshMin != cube.gridMin(axis) : meshMax != cube.gridMax(axis);
     }
 
     private static int component(Vector3i vector, Axis axis) {
@@ -155,8 +191,8 @@ public final class LittleTilesFaceCuller {
                     }
                 }
                 for (LittleTilesCubeObject occluder : neighbourCubes) {
-                    if (canOcclude(occluder, cube) && hasUncutSolidSide(occluder, side.getOpposite())) {
-                        coverSide(clippers[i], cube, occluder, side);
+                    if (canOcclude(occluder, cube)) {
+                        coverFlushSide(clippers[i], cube, occluder, side);
                     }
                 }
             }
@@ -184,7 +220,8 @@ public final class LittleTilesFaceCuller {
         ArrayList<LittleTilesCubeObject> cubes = new ArrayList<>();
         for (LittleTile tile : snapshot) {
             for (LittleTilesCubeObject cube : tile.getRenderingCubes()) {
-                if (!ignoreForCulling(cube) && touchesBorder(cube, border) && hasUncutSolidSide(cube, border)) {
+                if (!ignoreForCulling(cube) && touchesBorder(cube, border)
+                        && (hasUncutSolidSide(cube, border) || hasUncutPrismSide(cube, border))) {
                     cubes.add(cube);
                 }
             }
@@ -218,10 +255,22 @@ public final class LittleTilesFaceCuller {
             Axis axis = Axis.getAxis(side);
             boolean flush = RotationUtils.isNegative(side) ? occluder.gridMax(axis) == cube.gridMin(axis)
                     : occluder.gridMin(axis) == cube.gridMax(axis);
-            if (!flush || !hasUncutSolidSide(occluder, side.getOpposite())) {
-                continue;
+            if (flush) {
+                coverFlushSide(clipper, cube, occluder, side);
             }
+        }
+    }
+
+    /**
+     * Hides what the occluder sitting flush against the given side of {@code cube} covers there: either a rectangle of
+     * the box face, or, for two meshes meeting end to end, the whole face.
+     */
+    private static void coverFlushSide(FaceClipper clipper, LittleTilesCubeObject cube, LittleTilesCubeObject occluder,
+            ForgeDirection side) {
+        if (hasUncutSolidSide(occluder, side.getOpposite())) {
             coverSide(clipper, cube, occluder, side);
+        } else if (isMatchingPrismSide(cube, occluder, side)) {
+            clipper.cullSide(side);
         }
     }
 

--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
@@ -88,7 +88,7 @@ public final class LittleTilesFaceCuller {
         return RotationUtils.isNegative(side) ? cube.gridMin(axis) == 0 : cube.gridMax(axis) == 16;
     }
 
-    private static boolean hasUncutSolidSide(LittleTilesCubeObject cube, ForgeDirection side) {
+    static boolean hasUncutSolidSide(LittleTilesCubeObject cube, ForgeDirection side) {
         if (cube.cutoutInfo == null) {
             return true;
         }

--- a/src/main/java/com/creativemd/littletiles/client/render/SpecialBlockTilesRenderer.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/SpecialBlockTilesRenderer.java
@@ -55,11 +55,12 @@ public class SpecialBlockTilesRenderer extends TileEntitySpecialRenderer
             synchronized (tiles) {
                 snapshot = new ArrayList<>(tiles);
             }
+            ArrayList<LittleTilesCubeObject> cubes = new ArrayList<>();
             for (LittleTile tile : snapshot) {
-                ArrayList<LittleTilesCubeObject> cubes = tile.getRenderingCubes();
-                if (LittleTilesBlockRenderHelper.renderCubes(world, cubes, x, y, z, block, renderer, null)) {
-                    rendered = true;
-                }
+                cubes.addAll(tile.getRenderingCubes());
+            }
+            if (LittleTilesBlockRenderHelper.renderCubes(world, cubes, x, y, z, block, renderer, null)) {
+                rendered = true;
             }
         }
 

--- a/src/main/java/com/creativemd/littletiles/client/render/SpecialBlockTilesRenderer.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/SpecialBlockTilesRenderer.java
@@ -47,24 +47,19 @@ public class SpecialBlockTilesRenderer extends TileEntitySpecialRenderer
         if (renderer.hasOverrideBlockTexture()) return false;
 
         TileEntity tileEntity = world.getTileEntity(x, y, z);
-        boolean rendered = false;
-        if (tileEntity instanceof TileEntityLittleTiles) {
-            TileEntityLittleTiles little = (TileEntityLittleTiles) tileEntity;
-            List<LittleTile> tiles = little.getTiles();
-            List<LittleTile> snapshot;
-            synchronized (tiles) {
-                snapshot = new ArrayList<>(tiles);
-            }
-            ArrayList<LittleTilesCubeObject> cubes = new ArrayList<>();
-            for (LittleTile tile : snapshot) {
-                cubes.addAll(tile.getRenderingCubes());
-            }
-            if (LittleTilesBlockRenderHelper.renderCubes(world, cubes, x, y, z, block, renderer, null)) {
-                rendered = true;
-            }
-        }
+        if (!(tileEntity instanceof TileEntityLittleTiles)) return false;
 
-        return rendered;
+        TileEntityLittleTiles little = (TileEntityLittleTiles) tileEntity;
+        List<LittleTile> tiles = little.getTiles();
+        List<LittleTile> snapshot;
+        synchronized (tiles) {
+            snapshot = new ArrayList<>(tiles);
+        }
+        ArrayList<LittleTilesCubeObject> cubes = new ArrayList<>();
+        for (LittleTile tile : snapshot) {
+            cubes.addAll(tile.getRenderingCubes());
+        }
+        return LittleTilesBlockRenderHelper.renderCubes(world, cubes, x, y, z, block, renderer, null);
     }
 
     @Override

--- a/src/main/java/com/creativemd/littletiles/client/util3d/Mesh3d.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/Mesh3d.java
@@ -20,6 +20,9 @@ import cpw.mods.fml.common.FMLLog;
 
 public class Mesh3d {
 
+    private static final double DEGENERATE_EPSILON = 1.0E-8;
+    private static final double DEGENERATE_EPSILON_SQUARED = DEGENERATE_EPSILON * DEGENERATE_EPSILON;
+
     private final List<Triangle3d> triangles;
 
     public Mesh3d(List<Triangle3d> triangles) {
@@ -84,9 +87,11 @@ public class Mesh3d {
 
             if (above.isEmpty()) {
                 // Entire triangle is below the plane, keep it
-                newTriangles.add(triangle);
-                if (on.size() == 2) {
-                    existingEdges.add(new Edge3d(on.get(0), on.get(1)));
+                if (!isDegenerate(triangle.getP1(), triangle.getP2(), triangle.getP3())) {
+                    newTriangles.add(triangle);
+                    if (on.size() == 2) {
+                        existingEdges.add(new Edge3d(on.get(0), on.get(1)));
+                    }
                 }
             } else if (below.isEmpty()) {
                 // SKIP
@@ -144,7 +149,9 @@ public class Mesh3d {
     }
 
     public static boolean isDegenerate(Vector3d p1, Vector3d p2, Vector3d p3) {
-        if (p1.equals(p2) || p1.equals(p3) || p2.equals(p3)) {
+        if (distanceSquared(p1, p2) <= DEGENERATE_EPSILON_SQUARED
+                || distanceSquared(p1, p3) <= DEGENERATE_EPSILON_SQUARED
+                || distanceSquared(p2, p3) <= DEGENERATE_EPSILON_SQUARED) {
             return true;
         }
 
@@ -153,7 +160,14 @@ public class Mesh3d {
         Vector3d edge2 = new Vector3d(p3);
         edge2.sub(p1);
         edge1.cross(edge1, edge2);
-        return edge1.lengthSquared() == 0;
+        return edge1.lengthSquared() <= DEGENERATE_EPSILON_SQUARED;
+    }
+
+    private static double distanceSquared(Vector3d p1, Vector3d p2) {
+        double dx = p1.x - p2.x;
+        double dy = p1.y - p2.y;
+        double dz = p1.z - p2.z;
+        return dx * dx + dy * dy + dz * dz;
     }
 
     // Handles case when 2 vertices are below the plane, 1 is above

--- a/src/main/java/com/creativemd/littletiles/client/util3d/Mesh3dUtil.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/Mesh3dUtil.java
@@ -1,9 +1,12 @@
 package com.creativemd.littletiles.client.util3d;
 
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
 import net.minecraft.block.Block;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import org.joml.Matrix3f;
 import org.joml.Vector3f;
@@ -23,6 +26,8 @@ public class Mesh3dUtil {
     private static Mesh3d MESH_SLOPE_TRIANGLE_CORNER;
     private static Mesh3d MESH_SLOPE_OUTER_CORNER;
     private static Mesh3d MESH_SLOPE_INNER_CORNER;
+    private static final boolean[] EMPTY_SOLID_SIDES = new boolean[6];
+    private static final Map<LittleTileShapeMode, boolean[]> SOLID_SIDES = new EnumMap<>(LittleTileShapeMode.class);
 
     public static void initializeMeshes() {
         MESH_SLOPE = Mesh3dObjLoader.load("slope");
@@ -32,6 +37,34 @@ public class Mesh3dUtil {
         MESH_SLOPE_TRIANGLE_CORNER = Mesh3dObjLoader.load("slope_triangle_corner");
         MESH_SLOPE_OUTER_CORNER = Mesh3dObjLoader.load("slope_outer");
         MESH_SLOPE_INNER_CORNER = Mesh3dObjLoader.load("slope_inner");
+
+        SOLID_SIDES.clear();
+        SOLID_SIDES.put(LittleTileShapeMode.SLOPE, solidSides(ForgeDirection.DOWN, ForgeDirection.NORTH));
+        SOLID_SIDES.put(LittleTileShapeMode.SLOPE_CONCAVE, solidSides(ForgeDirection.DOWN, ForgeDirection.NORTH));
+        SOLID_SIDES.put(LittleTileShapeMode.SLOPE_CONVEX, solidSides(ForgeDirection.DOWN, ForgeDirection.NORTH));
+        SOLID_SIDES.put(LittleTileShapeMode.SLOPE_TRIANGLE, solidSides());
+        SOLID_SIDES.put(
+                LittleTileShapeMode.SLOPE_TRIANGLE_CORNER,
+                solidSides(ForgeDirection.DOWN, ForgeDirection.NORTH, ForgeDirection.EAST));
+        SOLID_SIDES.put(
+                LittleTileShapeMode.SLOPE_OUTER_CORNER,
+                solidSides(ForgeDirection.DOWN, ForgeDirection.NORTH, ForgeDirection.EAST));
+        SOLID_SIDES.put(
+                LittleTileShapeMode.SLOPE_INNER_CORNER,
+                solidSides(ForgeDirection.DOWN, ForgeDirection.NORTH, ForgeDirection.EAST));
+    }
+
+    public static boolean[] getSolidSides(LittleTileShapeMode shape) {
+        boolean[] sides = SOLID_SIDES.get(shape);
+        return sides != null ? sides : EMPTY_SOLID_SIDES;
+    }
+
+    private static boolean[] solidSides(ForgeDirection... sides) {
+        boolean[] solidSides = new boolean[6];
+        for (ForgeDirection side : sides) {
+            solidSides[side.ordinal()] = true;
+        }
+        return solidSides;
     }
 
     public static Mesh3d meshFromTile(LittleTileBox box, LittleTileCutoutInfo cutoutInfo) {

--- a/src/main/java/com/creativemd/littletiles/client/util3d/Mesh3dUtil.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/Mesh3dUtil.java
@@ -26,8 +26,9 @@ public class Mesh3dUtil {
     private static Mesh3d MESH_SLOPE_TRIANGLE_CORNER;
     private static Mesh3d MESH_SLOPE_OUTER_CORNER;
     private static Mesh3d MESH_SLOPE_INNER_CORNER;
-    private static final boolean[] EMPTY_SOLID_SIDES = new boolean[6];
+    private static final boolean[] EMPTY_SIDES = new boolean[6];
     private static final Map<LittleTileShapeMode, boolean[]> SOLID_SIDES = new EnumMap<>(LittleTileShapeMode.class);
+    private static final Map<LittleTileShapeMode, boolean[]> PRISM_SIDES = new EnumMap<>(LittleTileShapeMode.class);
 
     public static void initializeMeshes() {
         MESH_SLOPE = Mesh3dObjLoader.load("slope");
@@ -52,11 +53,28 @@ public class Mesh3dUtil {
         SOLID_SIDES.put(
                 LittleTileShapeMode.SLOPE_INNER_CORNER,
                 solidSides(ForgeDirection.DOWN, ForgeDirection.NORTH, ForgeDirection.EAST));
+
+        // The slope meshes are prisms along X, so their two X sides are the shape's flat cross-section.
+        PRISM_SIDES.clear();
+        PRISM_SIDES.put(LittleTileShapeMode.SLOPE, solidSides(ForgeDirection.WEST, ForgeDirection.EAST));
+        PRISM_SIDES.put(LittleTileShapeMode.SLOPE_CONCAVE, solidSides(ForgeDirection.WEST, ForgeDirection.EAST));
+        PRISM_SIDES.put(LittleTileShapeMode.SLOPE_CONVEX, solidSides(ForgeDirection.WEST, ForgeDirection.EAST));
     }
 
+    /** The sides on which the shape has a flat face covering the whole box side, in the mesh's base orientation. */
     public static boolean[] getSolidSides(LittleTileShapeMode shape) {
         boolean[] sides = SOLID_SIDES.get(shape);
-        return sides != null ? sides : EMPTY_SOLID_SIDES;
+        return sides != null ? sides : EMPTY_SIDES;
+    }
+
+    /**
+     * The sides on which the shape has a flat face that is its cross-section, in the mesh's base orientation. Unlike a
+     * solid side such a face does not cover the whole box side - a slope's ends are triangles - so it can only ever be
+     * hidden by the identical cross-section of another mesh of the same shape.
+     */
+    public static boolean[] getPrismSides(LittleTileShapeMode shape) {
+        boolean[] sides = PRISM_SIDES.get(shape);
+        return sides != null ? sides : EMPTY_SIDES;
     }
 
     private static boolean[] solidSides(ForgeDirection... sides) {

--- a/src/main/java/com/creativemd/littletiles/common/gui/controls/GuiTileViewer.java
+++ b/src/main/java/com/creativemd/littletiles/common/gui/controls/GuiTileViewer.java
@@ -40,7 +40,7 @@ public class GuiTileViewer extends GuiControl {
     public boolean visibleAxis = false;
 
     public Axis normalAxis = null;
-    public Axis axisDirection = Axis.Yaxis;
+    public Axis axisDirection = Axis.AxisY;
     public int axisX = 0;
     public int axisY = 0;
     public int axisZ = 0;
@@ -76,17 +76,17 @@ public class GuiTileViewer extends GuiControl {
         double sizeZ = maxZ - minZ;
 
         switch (axisDirection) {
-            case Xaxis:
-                if (sizeY >= sizeZ) normalAxis = Axis.Zaxis;
-                else normalAxis = Axis.Yaxis;
+            case AxisX:
+                if (sizeY >= sizeZ) normalAxis = Axis.AxisZ;
+                else normalAxis = Axis.AxisY;
                 break;
-            case Yaxis:
-                if (sizeX >= sizeZ) normalAxis = Axis.Zaxis;
-                else normalAxis = Axis.Xaxis;
+            case AxisY:
+                if (sizeX >= sizeZ) normalAxis = Axis.AxisZ;
+                else normalAxis = Axis.AxisX;
                 break;
-            case Zaxis:
-                if (sizeX >= sizeY) normalAxis = Axis.Yaxis;
-                else normalAxis = Axis.Xaxis;
+            case AxisZ:
+                if (sizeX >= sizeY) normalAxis = Axis.AxisY;
+                else normalAxis = Axis.AxisX;
                 break;
             default:
                 break;
@@ -95,17 +95,17 @@ public class GuiTileViewer extends GuiControl {
 
     public void changeNormalAxis() {
         switch (axisDirection) {
-            case Xaxis:
-                if (normalAxis == Axis.Zaxis) normalAxis = Axis.Yaxis;
-                else normalAxis = Axis.Zaxis;
+            case AxisX:
+                if (normalAxis == Axis.AxisZ) normalAxis = Axis.AxisY;
+                else normalAxis = Axis.AxisZ;
                 break;
-            case Yaxis:
-                if (normalAxis == Axis.Zaxis) normalAxis = Axis.Xaxis;
-                else normalAxis = Axis.Zaxis;
+            case AxisY:
+                if (normalAxis == Axis.AxisZ) normalAxis = Axis.AxisX;
+                else normalAxis = Axis.AxisZ;
                 break;
-            case Zaxis:
-                if (normalAxis == Axis.Yaxis) normalAxis = Axis.Xaxis;
-                else normalAxis = Axis.Yaxis;
+            case AxisZ:
+                if (normalAxis == Axis.AxisY) normalAxis = Axis.AxisX;
+                else normalAxis = Axis.AxisY;
                 break;
             default:
                 break;
@@ -195,17 +195,17 @@ public class GuiTileViewer extends GuiControl {
             cube.block = Blocks.wool;
             cube.meta = 0;
             switch (normalAxis) {
-                case Xaxis:
+                case AxisX:
                     // cube.minZ = min;
                     // cube.maxZ = max;
                     cube.minX = min;
                     cube.maxX = max;
                     break;
-                case Yaxis:
+                case AxisY:
                     cube.minY = min;
                     cube.maxY = max;
                     break;
-                case Zaxis:
+                case AxisZ:
                     // cube.minX = min;
                     // cube.maxX = max;
                     cube.minZ = min;
@@ -220,17 +220,17 @@ public class GuiTileViewer extends GuiControl {
             cube.meta = 5;
 
             switch (axisDirection) {
-                case Xaxis:
+                case AxisX:
                     // cube.minZ = min;
                     // cube.maxZ = max;
                     cube.minX = min;
                     cube.maxX = max;
                     break;
-                case Yaxis:
+                case AxisY:
                     cube.minY = min;
                     cube.maxY = max;
                     break;
-                case Zaxis:
+                case AxisZ:
                     // cube.minX = min;
                     // cube.maxX = max;
                     cube.minZ = min;
@@ -337,14 +337,14 @@ public class GuiTileViewer extends GuiControl {
 
     public void updateViewDirection() {
         switch (axisDirection) {
-            case Xaxis:
-                viewDirection = Axis.Zaxis.getDirection();
+            case AxisX:
+                viewDirection = Axis.AxisZ.getDirection();
                 break;
-            case Yaxis:
-                viewDirection = Axis.Yaxis.getDirection();
+            case AxisY:
+                viewDirection = Axis.AxisY.getDirection();
                 break;
-            case Zaxis:
-                viewDirection = Axis.Xaxis.getDirection();
+            case AxisZ:
+                viewDirection = Axis.AxisX.getDirection();
                 break;
             default:
                 break;

--- a/src/main/java/com/creativemd/littletiles/common/structure/LittleDoor.java
+++ b/src/main/java/com/creativemd/littletiles/common/structure/LittleDoor.java
@@ -105,14 +105,14 @@ public class LittleDoor extends LittleStructure {
         GuiTileViewer viewer = (GuiTileViewer) event.source.parent.getControl("tileviewer");
         if (event.source.is("swap axis")) {
             switch (viewer.axisDirection) {
-                case Xaxis:
-                    axis = Axis.Yaxis;
+                case AxisX:
+                    axis = Axis.AxisY;
                     break;
-                case Yaxis:
-                    axis = Axis.Zaxis;
+                case AxisY:
+                    axis = Axis.AxisZ;
                     break;
-                case Zaxis:
-                    axis = Axis.Xaxis;
+                case AxisZ:
+                    axis = Axis.AxisX;
                     break;
                 default:
                     break;
@@ -134,20 +134,20 @@ public class LittleDoor extends LittleStructure {
             // viewer.viewDirection = ForgeDirection.getOrientation(((GuiStateButton) event.source).getState()+2);
         } else if (event.source instanceof GuiButton) {
             if (event.source.is("<-")) {
-                if (viewer.axisDirection == Axis.Xaxis) viewer.axisZ++;
+                if (viewer.axisDirection == Axis.AxisX) viewer.axisZ++;
                 else viewer.axisX--;
             }
             if (event.source.is("->")) {
-                if (viewer.axisDirection == Axis.Xaxis) viewer.axisZ--;
+                if (viewer.axisDirection == Axis.AxisX) viewer.axisZ--;
                 else viewer.axisX++;
             }
             if (event.source.is("up")) {
-                if (viewer.axisDirection == Axis.Yaxis) viewer.axisZ--;
+                if (viewer.axisDirection == Axis.AxisY) viewer.axisZ--;
                 else viewer.axisY++;
 
             }
             if (event.source.is("down")) {
-                if (viewer.axisDirection == Axis.Yaxis) viewer.axisZ++;
+                if (viewer.axisDirection == Axis.AxisY) viewer.axisZ++;
                 else viewer.axisY--;
             } else if (event.source.is("swap normal")) {
                 viewer.changeNormalAxis();
@@ -206,9 +206,9 @@ public class LittleDoor extends LittleStructure {
         // if(RotationUtils.isNegative(normalDirection))
         // normalDirection = normalDirection.getOpposite();
         /*
-         * Axis before = axis; if(axisDirection == Axis.Yaxis) { switch(axis) { case Xaxis: this.axis = Axis.Yaxis;
-         * break; case Yaxis: this.axis = Axis.Xaxis; break; default: break; } }else{ switch(axis) { case Xaxis:
-         * this.axis = Axis.Zaxis; break; case Zaxis: this.axis = Axis.Xaxis; break; default: break; } }
+         * Axis before = axis; if(axisDirection == Axis.AxisY) { switch(axis) { case AxisX: this.axis = Axis.AxisY;
+         * break; case AxisY: this.axis = Axis.AxisX; break; default: break; } }else{ switch(axis) { case AxisX:
+         * this.axis = Axis.AxisZ; break; case AxisZ: this.axis = Axis.AxisX; break; default: break; } }
          */
         // if(before != axis)
         // updateNormalDirection();
@@ -277,11 +277,11 @@ public class LittleDoor extends LittleStructure {
         structure.normalDirection = this.normalDirection.getRotation(rotationAxis);
 
         /*
-         * Axis directionAxis = Axis.getAxis(this.axis); switch(directionAxis) { case Xaxis: if(directionAxis ==
-         * Axis.Yaxis) structure.normalAxis = Axis.Zaxis; else structure.normalAxis = Axis.Yaxis; break; case Yaxis:
-         * if(directionAxis == Axis.Zaxis) structure.normalAxis = Axis.Xaxis; else structure.normalAxis = Axis.Zaxis;
-         * break; case Zaxis: if(directionAxis == Axis.Yaxis) structure.normalAxis = Axis.Xaxis; else
-         * structure.normalAxis = Axis.Yaxis; break; default: break; }
+         * Axis directionAxis = Axis.getAxis(this.axis); switch(directionAxis) { case AxisX: if(directionAxis ==
+         * Axis.AxisY) structure.normalAxis = Axis.AxisZ; else structure.normalAxis = Axis.AxisY; break; case AxisY:
+         * if(directionAxis == Axis.AxisZ) structure.normalAxis = Axis.AxisX; else structure.normalAxis = Axis.AxisZ;
+         * break; case AxisZ: if(directionAxis == Axis.AxisY) structure.normalAxis = Axis.AxisX; else
+         * structure.normalAxis = Axis.AxisY; break; default: break; }
          */
 
         if (ItemBlockTiles.placeTiles(
@@ -369,7 +369,7 @@ public class LittleDoor extends LittleStructure {
             boolean inverse = false;
 
             switch (axis) {
-                case Xaxis:
+                case AxisX:
                     // System.out.println(player.rotationPitch);
                     System.out.println(normalDirection);
                     rotation = Rotation.UPX;
@@ -391,7 +391,7 @@ public class LittleDoor extends LittleStructure {
                     }
                     inverse = rotation == Rotation.UPX;
                     break;
-                case Yaxis:
+                case AxisY:
                     rotation = Rotation.SOUTH;
                     switch (normalDirection) {
                         case EAST:
@@ -411,7 +411,7 @@ public class LittleDoor extends LittleStructure {
                     }
                     inverse = rotation == Rotation.SOUTH;
                     break;
-                case Zaxis:
+                case AxisZ:
                     // System.out.println(player.rotationPitch);
                     // System.out.println(normalDirection);
                     rotation = Rotation.UP;
@@ -461,14 +461,14 @@ public class LittleDoor extends LittleStructure {
 
     public void updateNormalDirection() {
         switch (axis) {
-            case Xaxis:
-                normalDirection = Axis.Zaxis.getDirection();
+            case AxisX:
+                normalDirection = Axis.AxisZ.getDirection();
                 break;
-            case Yaxis:
-                normalDirection = Axis.Xaxis.getDirection();
+            case AxisY:
+                normalDirection = Axis.AxisX.getDirection();
                 break;
-            case Zaxis:
-                normalDirection = Axis.Yaxis.getDirection();
+            case AxisZ:
+                normalDirection = Axis.AxisY.getDirection();
                 break;
             default:
                 break;

--- a/src/main/java/com/creativemd/littletiles/common/structure/PreviewTileAxis.java
+++ b/src/main/java/com/creativemd/littletiles/common/structure/PreviewTileAxis.java
@@ -53,15 +53,15 @@ public class PreviewTileAxis extends PreviewTile {
         int max = 40 * 16;
         int min = -max;
         switch (axis) {
-            case Xaxis:
+            case AxisX:
                 preview.minX = min;
                 preview.maxX = max;
                 break;
-            case Yaxis:
+            case AxisY:
                 preview.minY = min;
                 preview.maxY = max;
                 break;
-            case Zaxis:
+            case AxisZ:
                 preview.minZ = min;
                 preview.maxZ = max;
                 break;

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTile.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTile.java
@@ -303,6 +303,7 @@ public abstract class LittleTile {
         if (boundingBox != null) {
             tile.boundingBox = boundingBox.copy();
         }
+        tile.cutoutInfo = cutoutInfo != null ? new LittleTileCutoutInfo(cutoutInfo) : null;
         tile.cornerVec = this.cornerVec.copy();
         tile.te = this.te;
 
@@ -471,6 +472,11 @@ public abstract class LittleTile {
         for (LittleTileBox box : newBoxes) {
             LittleTile tile = this.copy();
             tile.boundingBox = box;
+            if (tile.cutoutInfo != null) {
+                tile.cutoutInfo.pos.x += boundingBox.minX - box.minX;
+                tile.cutoutInfo.pos.y += boundingBox.minY - box.minY;
+                tile.cutoutInfo.pos.z += boundingBox.minZ - box.minZ;
+            }
             ret.add(tile);
         }
         return ret;

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTilesCubeObject.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTilesCubeObject.java
@@ -4,9 +4,21 @@ import com.creativemd.creativecore.common.utils.CubeObject;
 
 public class LittleTilesCubeObject extends CubeObject {
 
-    public LittleTilesCubeObject(double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
-        super(minX, minY, minZ, maxX, maxY, maxZ);
-    }
-
     public LittleTileCutoutInfo cutoutInfo;
+
+    /**
+     * Bounds on the 1/16 grid. Kept alongside the double bounds so face occlusion can be computed with exact integer
+     * math.
+     */
+    public int gridMinX, gridMinY, gridMinZ, gridMaxX, gridMaxY, gridMaxZ;
+
+    public LittleTilesCubeObject(int minX, int minY, int minZ, int maxX, int maxY, int maxZ) {
+        super(minX / 16D, minY / 16D, minZ / 16D, maxX / 16D, maxY / 16D, maxZ / 16D);
+        this.gridMinX = minX;
+        this.gridMinY = minY;
+        this.gridMinZ = minZ;
+        this.gridMaxX = maxX;
+        this.gridMaxY = maxY;
+        this.gridMaxZ = maxZ;
+    }
 }

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTilesCubeObject.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTilesCubeObject.java
@@ -1,6 +1,10 @@
 package com.creativemd.littletiles.common.utils;
 
+import static com.creativemd.creativecore.common.utils.RotationUtils.Axis.AxisX;
+import static com.creativemd.creativecore.common.utils.RotationUtils.Axis.AxisY;
+
 import com.creativemd.creativecore.common.utils.CubeObject;
+import com.creativemd.creativecore.common.utils.RotationUtils.Axis;
 
 public class LittleTilesCubeObject extends CubeObject {
 
@@ -20,5 +24,13 @@ public class LittleTilesCubeObject extends CubeObject {
         this.gridMaxX = maxX;
         this.gridMaxY = maxY;
         this.gridMaxZ = maxZ;
+    }
+
+    public int gridMin(Axis axis) {
+        return axis == AxisX ? gridMinX : (axis == AxisY ? gridMinY : gridMinZ);
+    }
+
+    public int gridMax(Axis axis) {
+        return axis == AxisX ? gridMaxX : (axis == AxisY ? gridMaxY : gridMaxZ);
     }
 }

--- a/src/main/java/com/creativemd/littletiles/common/utils/small/LittleTileBox.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/small/LittleTileBox.java
@@ -91,7 +91,7 @@ public class LittleTileBox {
     }
 
     public LittleTilesCubeObject getCube() {
-        return new LittleTilesCubeObject(minX / 16D, minY / 16D, minZ / 16D, maxX / 16D, maxY / 16D, maxZ / 16D);
+        return new LittleTilesCubeObject(minX, minY, minZ, maxX, maxY, maxZ);
     }
 
     public void writeToNBT(String name, NBTTagCompound nbt) {


### PR DESCRIPTION
## Summary
Improved face culling as added by https://github.com/GTNewHorizons/LittleTiles/pull/122
Now also supports meshes.

<img width="998" height="1202" alt="image" src="https://github.com/user-attachments/assets/1f3b8f3b-c688-4097-ba9f-58dcf79e9aa4" />
<img width="1206" height="1207" alt="image" src="https://github.com/user-attachments/assets/94f13d71-6abf-4c64-bb60-2f4e94805dd9" />



## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
