### PR TITLE
Fix for blockpicked cutouts

### DIFF
--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
@@ -43,6 +43,10 @@ public class LittleTilesBlockRenderHelper {
             LittleTileShapeMode shapeMode) {
         LittleTileCutoutInfo cutoutInfo = new LittleTileCutoutInfo();
         cutoutInfo.type = shapeMode;
+        cutoutInfo.size = new Vector3i(
+                (int) Math.round(cutoutScale.x * 16),
+                (int) Math.round(cutoutScale.y * 16),
+                (int) Math.round(cutoutScale.z * 16));
         Mesh3d mesh = Mesh3dUtil.createMesh(
                 cutoutInfo,
                 cutoutScale,


### PR DESCRIPTION
## Summary
When blockpicking a part of a slope that spans multiple blocks it renders the whole slope as preview instead of just the piece you have in the hand. This PR fixes that.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
