### PR TITLE
Cache meshes clientside for rendering

### DIFF
--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
@@ -70,19 +70,13 @@ public class LittleTilesBlockRenderHelper {
     }
 
     private static boolean renderCutout(int x, int y, int z, LittleTilesCubeObject cube, IBlockAccess world) {
-        Mesh3d mesh = Mesh3dUtil.createMesh(
-                x,
-                y,
-                z,
-                cube.cutoutInfo,
-                cube.minX,
-                cube.minY,
-                cube.minZ,
-                cube.maxX,
-                cube.maxY,
-                cube.maxZ,
-                cube.block,
-                cube.meta);
+        Mesh3d cachedMesh = cube.renderCache.getSimpleMesh();
+        if (cachedMesh == null) {
+            return false;
+        }
+        Mesh3d mesh = cachedMesh.copy();
+        mesh.setTextures(cube.block, cube.meta);
+        mesh.translate(new Vector3d(x, y, z));
         Tessellator tess = Tessellator.instance;
 
         int brightness = cube.block.getMixedBrightnessForBlock(world, x, y, z);

--- a/src/main/java/com/creativemd/littletiles/common/tileentity/TileEntityLittleTiles.java
+++ b/src/main/java/com/creativemd/littletiles/common/tileentity/TileEntityLittleTiles.java
@@ -307,7 +307,7 @@ public class TileEntityLittleTiles extends TileEntity {
                     if (hit == null || hit.hitVec.distanceTo(pos) > Temphit.hitVec.distanceTo(pos) - EPSILON) {
                         boolean isHit = true;
                         if (tile.getCutoutInfo() != null) {
-                            Mesh3d mesh = Mesh3dUtil.meshFromTile(tile.boundingBox, tile.getCutoutInfo());
+                            Mesh3d mesh = tile.getSimpleMesh();
                             float distance = TriangleRayIntersect.intersects(mesh, xCoord, yCoord, zCoord, pos, look);
                             if (mesh.getTriangles().isEmpty()) {
                                 // Workaround for buggy, empty meshes

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTile.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTile.java
@@ -22,6 +22,8 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.EmptyChunk;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.creativemd.littletiles.client.util3d.Mesh3d;
+import com.creativemd.littletiles.client.util3d.Mesh3dUtil;
 import com.creativemd.littletiles.common.structure.LittleStructure;
 import com.creativemd.littletiles.common.tileentity.TileEntityLittleTiles;
 import com.creativemd.littletiles.common.utils.small.LittleTileBox;
@@ -29,6 +31,7 @@ import com.creativemd.littletiles.common.utils.small.LittleTileCoord;
 import com.creativemd.littletiles.common.utils.small.LittleTileSize;
 import com.creativemd.littletiles.common.utils.small.LittleTileVec;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -119,6 +122,8 @@ public abstract class LittleTile {
 
     private LittleTileCutoutInfo cutoutInfo = null;
 
+    private final LittleTileRenderCache renderCache = new LittleTileRenderCache(this);
+
     public AxisAlignedBB getSelectedBox() {
         if (boundingBox != null) {
             return boundingBox.getBox();
@@ -171,6 +176,7 @@ public abstract class LittleTile {
         if (count > 0) {
             boundingBox = new LittleTileBox("bBox" + 0, nbt);
         }
+        invalidateClientMeshCache();
         updateCorner();
     }
 
@@ -243,6 +249,7 @@ public abstract class LittleTile {
         }
 
         cutoutInfo = LittleTileCutoutInfo.loadFromNBT(nbt);
+        invalidateClientMeshCache();
     }
 
     // ================Placing================
@@ -256,6 +263,7 @@ public abstract class LittleTile {
         if (boundingBox != null) {
             cornerVec = new LittleTileVec(boundingBox.minX, boundingBox.minY, boundingBox.minZ);
         } else cornerVec = new LittleTileVec(0, 0, 0);
+        invalidateClientMeshCache();
     }
 
     public void place() {
@@ -305,6 +313,8 @@ public abstract class LittleTile {
         }
         tile.cornerVec = this.cornerVec.copy();
         tile.te = this.te;
+        tile.cutoutInfo = cutoutInfo == null ? null : new LittleTileCutoutInfo(cutoutInfo);
+        tile.invalidateClientMeshCache();
 
         tile.structure = this.structure;
         if (this.coord != null) tile.coord = this.coord.copy();
@@ -451,10 +461,30 @@ public abstract class LittleTile {
 
     public void setCutoutInfo(LittleTileCutoutInfo cutoutInfo) {
         this.cutoutInfo = cutoutInfo;
+        invalidateClientMeshCache();
     }
 
     public LittleTileCutoutInfo getCutoutInfo() {
         return cutoutInfo;
+    }
+
+    public Mesh3d getSimpleMesh() {
+        if (cutoutInfo == null || boundingBox == null) {
+            return null;
+        }
+        if (FMLCommonHandler.instance().getEffectiveSide().isClient()) {
+            return renderCache.getSimpleMesh();
+        }
+        return Mesh3dUtil.meshFromTile(boundingBox, cutoutInfo);
+    }
+
+    private void invalidateClientMeshCache() {
+        renderCache.invalidateMesh();
+    }
+
+    @SideOnly(Side.CLIENT)
+    public LittleTileRenderCache getRenderCache() {
+        return renderCache;
     }
 
     public boolean overlapsTile(LittleTile other) {

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTileBlock.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTileBlock.java
@@ -76,6 +76,7 @@ public class LittleTileBlock extends LittleTile {
             cube.block = block;
             cube.meta = meta;
             cube.cutoutInfo = this.getCutoutInfo();
+            cube.renderCache = getRenderCache();
             cubes.add(cube);
         }
         return cubes;

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTileRenderCache.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTileRenderCache.java
@@ -1,0 +1,31 @@
+package com.creativemd.littletiles.common.utils;
+
+import com.creativemd.littletiles.client.util3d.Mesh3d;
+import com.creativemd.littletiles.client.util3d.Mesh3dUtil;
+
+/**
+ * Client render geometry retained for a little tile.
+ */
+public class LittleTileRenderCache {
+
+    private final LittleTile tile;
+    private volatile Mesh3d simpleMesh;
+
+    public LittleTileRenderCache(LittleTile tile) {
+        this.tile = tile;
+    }
+
+    public Mesh3d getSimpleMesh() {
+        if (tile.getCutoutInfo() == null || tile.boundingBox == null) {
+            return null;
+        }
+        if (simpleMesh == null) {
+            simpleMesh = Mesh3dUtil.meshFromTile(tile.boundingBox, tile.getCutoutInfo());
+        }
+        return simpleMesh;
+    }
+
+    public void invalidateMesh() {
+        simpleMesh = null;
+    }
+}

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTilesCubeObject.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTilesCubeObject.java
@@ -9,6 +9,7 @@ import com.creativemd.creativecore.common.utils.RotationUtils.Axis;
 public class LittleTilesCubeObject extends CubeObject {
 
     public LittleTileCutoutInfo cutoutInfo;
+    public LittleTileRenderCache renderCache;
 
     /**
      * Bounds on the 1/16 grid. Kept alongside the double bounds so face occlusion can be computed with exact integer


### PR DESCRIPTION
## Summary
Cutting meshes is fairly CPU intensive, slowing down chunk rebuilds. This PR aims to address this issue by caching unchanged meshes clientside. Also in preparation for caching culling state, since that is super expensive too.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
