### PR TITLE
Add command to dump mesh

### DIFF
--- a/src/main/java/com/creativemd/littletiles/client/LittleTilesClient.java
+++ b/src/main/java/com/creativemd/littletiles/client/LittleTilesClient.java
@@ -2,10 +2,12 @@ package com.creativemd.littletiles.client;
 
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.item.Item;
+import net.minecraftforge.client.ClientCommandHandler;
 import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.common.MinecraftForge;
 
 import com.creativemd.littletiles.LittleTiles;
+import com.creativemd.littletiles.client.command.DumpMeshCommand;
 import com.creativemd.littletiles.client.render.BlockOverlayRenderer;
 import com.creativemd.littletiles.client.render.PreviewRenderer;
 import com.creativemd.littletiles.client.render.SpecialBlockTilesRenderer;
@@ -59,6 +61,7 @@ public class LittleTilesClient extends LittleTilesServer {
         ClientRegistry.registerKeyBinding(mark);
         ClientRegistry.registerKeyBinding(toolConfig);
         MinecraftForgeClient.registerItemRenderer(LittleTiles.chisel, new BlockOverlayRenderer());
+        ClientCommandHandler.instance.registerCommand(new DumpMeshCommand());
     }
 
 }

--- a/src/main/java/com/creativemd/littletiles/client/command/DumpMeshCommand.java
+++ b/src/main/java/com/creativemd/littletiles/client/command/DumpMeshCommand.java
@@ -1,0 +1,71 @@
+package com.creativemd.littletiles.client.command;
+
+import java.io.File;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.MovingObjectPosition.MovingObjectType;
+
+import com.creativemd.littletiles.client.util3d.Mesh3d;
+import com.creativemd.littletiles.common.tileentity.TileEntityLittleTiles;
+
+public class DumpMeshCommand extends CommandBase {
+
+    private static final String ERROR_KEY = "littletiles.command.dumpmesh.error";
+    private static final String SUCCESS_KEY = "littletiles.command.dumpmesh.success";
+
+    @Override
+    public String getCommandName() {
+        return "ltdumpmesh";
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return "/ltdumpmesh";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 0;
+    }
+
+    @Override
+    public boolean canCommandSenderUseCommand(ICommandSender sender) {
+        return true;
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+        Minecraft mc = Minecraft.getMinecraft();
+        EntityPlayer player = mc.thePlayer;
+
+        Mesh3d mesh = findMesh(player, mc.objectMouseOver);
+        if (mesh == null || mesh.getTriangles().isEmpty()) {
+            sender.addChatMessage(new ChatComponentTranslation(ERROR_KEY));
+            return;
+        }
+
+        File outFile = mesh.dumpMesh();
+        sender.addChatMessage(new ChatComponentTranslation(SUCCESS_KEY, "logs/" + outFile.getName()));
+    }
+
+    private static Mesh3d findMesh(EntityPlayer player, MovingObjectPosition look) {
+        if (look == null || look.typeOfHit != MovingObjectType.BLOCK) {
+            return null;
+        }
+        TileEntity te = player.worldObj.getTileEntity(look.blockX, look.blockY, look.blockZ);
+        if (!(te instanceof TileEntityLittleTiles)) {
+            return null;
+        }
+        TileEntityLittleTiles teLT = (TileEntityLittleTiles) te;
+        if (!teLT.updateLoadedTile(player)) {
+            return null;
+        }
+        return teLT.loadedTile.getSimpleMesh();
+    }
+}

--- a/src/main/java/com/creativemd/littletiles/client/util3d/Mesh3d.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/Mesh3d.java
@@ -51,6 +51,22 @@ public class Mesh3d {
     }
 
     private static int logCount;
+    private static int dumpCount;
+
+    public File dumpMesh() {
+        File mcDir;
+        if (FMLCommonHandler.instance().getSide().isClient()) {
+            mcDir = Minecraft.getMinecraft().mcDataDir;
+        } else {
+            mcDir = new File(".");
+        }
+        File logsFolder = new File(mcDir, "logs");
+        File outFile = new File(logsFolder, "littleTilesDumpMesh" + dumpCount + ".obj");
+        dumpCount++;
+        exportObj(outFile);
+        FMLLog.getLogger().info("Dumped mesh into " + outFile.getAbsolutePath());
+        return outFile;
+    }
 
     private void dumpFailingMesh() {
         File mcDir;

--- a/src/main/resources/assets/littletiles/lang/en_US.lang
+++ b/src/main/resources/assets/littletiles/lang/en_US.lang
@@ -50,3 +50,5 @@ key.littletiles.mode_stencil=Stencil Mode
 key.littletiles.mode_stencil_info=Doesn't place anything. Removes tiles at overlapping space.
 itemGroup.littletiles=Little Tiles
 block.LTBlocks.missingblock.name=§cMissing block! Is this a tile using a modded block from a mod you removed?
+littletiles.command.dumpmesh.error=No mesh under cursor.
+littletiles.command.dumpmesh.success=Mesh dumped to %s


### PR DESCRIPTION
## Summary
Adds a command to dump a mesh for easier debugging and sharing of broken meshes.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
