### PR TITLE
Rotation cleanup

### DIFF
--- a/src/main/java/com/creativemd/littletiles/common/items/ItemBlockTiles.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemBlockTiles.java
@@ -243,9 +243,9 @@ public class ItemBlockTiles extends ItemBlock implements ILittleTile, ITilesRend
     @Override
     public void rotateLittlePreview(ItemStack stack, ForgeDirection direction) {
         if (!stack.hasTagCompound()) return;
-        NBTTagCompound old = (NBTTagCompound) stack.stackTagCompound.copy();
+        LittleTileSize oldSize = LittleTilePreview.getSizeFromNBT(stack.stackTagCompound);
         LittleTilePreview.rotatePreview(stack.stackTagCompound, direction);
-        new LittleToolHandler(stack).handleRotation(direction, old);
+        new LittleToolHandler(stack).handleRotation(direction, oldSize);
     }
 
     @Override

--- a/src/main/java/com/creativemd/littletiles/common/items/ItemRecipe.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemRecipe.java
@@ -153,13 +153,12 @@ public class ItemRecipe extends Item implements ITilesRenderer, IGuiCreator {
             }
             LittleTilePreview.rotatePreview(nbt, direction);
             if (oldSize != null && nbt.hasKey("cutoutOrientation")) {
+                // Recipe tiles only carry a box, no size tag, so hand the box size over as the old size.
                 NBTTagCompound old = new NBTTagCompound();
                 old.setInteger("sizex", oldSize.sizeX);
                 old.setInteger("sizey", oldSize.sizeY);
                 old.setInteger("sizez", oldSize.sizeZ);
-                ItemStack previewStack = new ItemStack(Item.getItemFromBlock(LittleTiles.blockTile));
-                previewStack.stackTagCompound = nbt;
-                new LittleToolHandler(previewStack).handleRotation(direction, old);
+                new LittleToolHandler(nbt).handleRotation(direction, old);
             }
             stack.stackTagCompound.setTag("tile" + i, nbt);
         }

--- a/src/main/java/com/creativemd/littletiles/common/items/ItemRecipe.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemRecipe.java
@@ -26,7 +26,6 @@ import com.creativemd.littletiles.common.tileentity.TileEntityLittleTiles;
 import com.creativemd.littletiles.common.utils.LittleTile;
 import com.creativemd.littletiles.common.utils.LittleTilePreview;
 import com.creativemd.littletiles.common.utils.LittleToolHandler;
-import com.creativemd.littletiles.common.utils.small.LittleTileBox;
 import com.creativemd.littletiles.common.utils.small.LittleTileSize;
 import com.creativemd.littletiles.common.utils.small.LittleTileVec;
 
@@ -147,18 +146,10 @@ public class ItemRecipe extends Item implements ITilesRenderer, IGuiCreator {
         int tiles = stack.stackTagCompound.getInteger("tiles");
         for (int i = 0; i < tiles; i++) {
             NBTTagCompound nbt = stack.stackTagCompound.getCompoundTag("tile" + i);
-            LittleTileSize oldSize = null;
-            if (nbt.hasKey("bBoxminX")) {
-                oldSize = new LittleTileBox("bBox", nbt).getSize();
-            }
+            LittleTileSize oldSize = LittleTilePreview.getSizeFromNBT(nbt);
             LittleTilePreview.rotatePreview(nbt, direction);
-            if (oldSize != null && nbt.hasKey("cutoutOrientation")) {
-                // Recipe tiles only carry a box, no size tag, so hand the box size over as the old size.
-                NBTTagCompound old = new NBTTagCompound();
-                old.setInteger("sizex", oldSize.sizeX);
-                old.setInteger("sizey", oldSize.sizeY);
-                old.setInteger("sizez", oldSize.sizeZ);
-                new LittleToolHandler(nbt).handleRotation(direction, old);
+            if (nbt.hasKey("cutoutOrientation")) {
+                new LittleToolHandler(nbt).handleRotation(direction, oldSize);
             }
             stack.stackTagCompound.setTag("tile" + i, nbt);
         }

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTilePreview.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTilePreview.java
@@ -80,6 +80,20 @@ public final class LittleTilePreview {
         }
     }
 
+    /**
+     * Size of the tile the preview describes, or null if the nbt carries neither a box nor a size. The bounding box
+     * wins, since it is the actual extent of the tile. Multiblock previews (recipes) only ever carry boxes.
+     */
+    public static LittleTileSize getSizeFromNBT(NBTTagCompound nbt) {
+        if (nbt.hasKey("bBoxminX")) {
+            return new LittleTileBox("bBox", nbt).getSize();
+        }
+        if (nbt.hasKey("sizex")) {
+            return new LittleTileSize("size", nbt);
+        }
+        return null;
+    }
+
     public static void rotatePreview(NBTTagCompound nbt, ForgeDirection direction) {
         if (nbt.hasKey("sizex")) {
             LittleTileSize size = new LittleTileSize("size", nbt);

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleToolHandler.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleToolHandler.java
@@ -4,12 +4,15 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.Vec3;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.joml.Matrix3f;
 import org.joml.Vector3f;
 import org.joml.Vector3i;
 
+import com.creativemd.creativecore.common.utils.Rotation;
+import com.creativemd.creativecore.common.utils.RotationUtils;
 import com.creativemd.creativecore.lib.Vector3d;
 import com.creativemd.littletiles.client.util3d.OrientationMapper;
 import com.creativemd.littletiles.client.util3d.Plane3d;
@@ -149,17 +152,28 @@ public class LittleToolHandler {
         return ret.getDirection();
     }
 
+    private static Vector3f toVector3f(Vec3 vec) {
+        return new Vector3f((float) vec.xCoord, (float) vec.yCoord, (float) vec.zCoord);
+    }
+
+    /**
+     * The tile boxes are rotated by CreativeCore ({@link RotationUtils#applyVectorRotation}). The cutout lives in the
+     * very same coordinate space, so its rotation has to use exactly that convention. Building the matrix from
+     * hand-written angles instead got the sign wrong for {@link ForgeDirection#UP}/{@link ForgeDirection#DOWN}, which
+     * rotated the cutout against its box. Deriving the matrix from the images of the unit axes cannot drift apart.
+     */
+    private static Matrix3f getRotationMatrix(ForgeDirection direction) {
+        Rotation rotation = Rotation.getRotationByDirection(direction);
+        return new Matrix3f(
+                toVector3f(RotationUtils.applyVectorRotation(Vec3.createVectorHelper(1, 0, 0), rotation)),
+                toVector3f(RotationUtils.applyVectorRotation(Vec3.createVectorHelper(0, 1, 0), rotation)),
+                toVector3f(RotationUtils.applyVectorRotation(Vec3.createVectorHelper(0, 0, 1), rotation)));
+    }
+
     // Handles rotation for a cutout. Only 90 degrees and only one axis.
     public void handleRotation(ForgeDirection direction, NBTTagCompound old) {
-        // Get rotation the user requested
-        // Intentionally swapped Y and Z!
-        float rotZ = (float) Math.PI / 2 * -direction.offsetY;
-        float rotY = (float) Math.PI / 2 * -direction.offsetZ;
-        Matrix3f positionRotation = new Matrix3f().rotateY(rotY).rotateZ(rotZ);
-        Matrix3f orientationRotation = new Matrix3f(positionRotation);
-        if (direction.offsetY != 0) {
-            orientationRotation = new Matrix3f().rotateY(rotY).rotateZ(-rotZ);
-        }
+        // Get rotation the user requested, in the same convention the tile boxes are rotated with
+        Matrix3f rotation = getRotationMatrix(direction);
 
         // Get saved rotation
         int orientation = getOrientation();
@@ -206,12 +220,12 @@ public class LittleToolHandler {
             nbt.setInteger("cutoutPosZ", cutoutPosZ);
 
             // Rotate size as well
-            if (rotY != 0) {
+            if (direction.offsetZ != 0) {
                 int temp = cutoutSizeX;
                 cutoutSizeX = cutoutSizeZ;
                 cutoutSizeZ = temp;
             }
-            if (rotZ != 0) {
+            if (direction.offsetY != 0) {
                 int temp = cutoutSizeX;
                 cutoutSizeX = cutoutSizeY;
                 cutoutSizeY = temp;

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleToolHandler.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleToolHandler.java
@@ -16,6 +16,7 @@ import com.creativemd.creativecore.common.utils.RotationUtils;
 import com.creativemd.creativecore.lib.Vector3d;
 import com.creativemd.littletiles.client.util3d.OrientationMapper;
 import com.creativemd.littletiles.client.util3d.Plane3d;
+import com.creativemd.littletiles.common.utils.small.LittleTileSize;
 
 public class LittleToolHandler {
 
@@ -170,8 +171,13 @@ public class LittleToolHandler {
                 toVector3f(RotationUtils.applyVectorRotation(Vec3.createVectorHelper(0, 0, 1), rotation)));
     }
 
-    // Handles rotation for a cutout. Only 90 degrees and only one axis.
-    public void handleRotation(ForgeDirection direction, NBTTagCompound old) {
+    /**
+     * Handles rotation for a cutout. Only 90 degrees and only one axis.
+     *
+     * @param oldSize size of the tile before it got rotated, null if unknown. Without it the cutout keeps its position
+     *                and only the orientation is updated, which is all a cutout that still covers its whole tile needs.
+     */
+    public void handleRotation(ForgeDirection direction, LittleTileSize oldSize) {
         // Get rotation the user requested, in the same convention the tile boxes are rotated with
         Matrix3f rotation = getRotationMatrix(direction);
 
@@ -187,7 +193,7 @@ public class LittleToolHandler {
         NBTTagCompound nbt = getTag(true);
 
         // Handle rotation for block-picked tiles. We need to rotate the cutout pos/size as well...
-        if (nbt.hasKey("cutoutPosX") && old != null) {
+        if (nbt.hasKey("cutoutPosX") && oldSize != null) {
             int cutoutSizeX = nbt.getInteger("cutoutSizeX");
             int cutoutSizeY = nbt.getInteger("cutoutSizeY");
             int cutoutSizeZ = nbt.getInteger("cutoutSizeZ");
@@ -195,17 +201,14 @@ public class LittleToolHandler {
             int cutoutPosX = nbt.getInteger("cutoutPosX");
             int cutoutPosY = nbt.getInteger("cutoutPosY");
             int cutoutPosZ = nbt.getInteger("cutoutPosZ");
-            int sizex = old.getInteger("sizex");
-            int sizey = old.getInteger("sizey");
-            int sizez = old.getInteger("sizez");
 
             // Treat cutout pos + size as cuboid to rotate it properly
             int minX = cutoutPosX;
             int minY = cutoutPosY;
             int minZ = cutoutPosZ;
-            int maxX = minX + cutoutSizeX - sizex;
-            int maxY = minY + cutoutSizeY - sizey;
-            int maxZ = minZ + cutoutSizeZ - sizez;
+            int maxX = minX + cutoutSizeX - oldSize.sizeX;
+            int maxY = minY + cutoutSizeY - oldSize.sizeY;
+            int maxZ = minZ + cutoutSizeZ - oldSize.sizeZ;
 
             // Rotate cuboid
             Vector3f v1 = positionRotation.transform(new Vector3f(minX, minY, minZ));

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleToolHandler.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleToolHandler.java
@@ -222,21 +222,11 @@ public class LittleToolHandler {
             nbt.setInteger("cutoutPosY", cutoutPosY);
             nbt.setInteger("cutoutPosZ", cutoutPosZ);
 
-            // Rotate size as well
-            if (direction.offsetZ != 0) {
-                int temp = cutoutSizeX;
-                cutoutSizeX = cutoutSizeZ;
-                cutoutSizeZ = temp;
-            }
-            if (direction.offsetY != 0) {
-                int temp = cutoutSizeX;
-                cutoutSizeX = cutoutSizeY;
-                cutoutSizeY = temp;
-            }
-
-            nbt.setInteger("cutoutSizeX", cutoutSizeX);
-            nbt.setInteger("cutoutSizeY", cutoutSizeY);
-            nbt.setInteger("cutoutSizeZ", cutoutSizeZ);
+            // Rotate size as well. The rotation only permutes the axes, so the size just follows along.
+            Vector3f size = rotation.transform(new Vector3f(cutoutSizeX, cutoutSizeY, cutoutSizeZ));
+            nbt.setInteger("cutoutSizeX", Math.abs(Math.round(size.x)));
+            nbt.setInteger("cutoutSizeY", Math.abs(Math.round(size.y)));
+            nbt.setInteger("cutoutSizeZ", Math.abs(Math.round(size.z)));
 
             boolean negX = nbt.getBoolean("cutoutNegX");
             boolean negY = nbt.getBoolean("cutoutNegY");

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleToolHandler.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleToolHandler.java
@@ -186,7 +186,7 @@ public class LittleToolHandler {
         Matrix3f matrix = OrientationMapper.fromId(orientation);
 
         // Apply new rotation and save
-        matrix = new Matrix3f(orientationRotation).mul(matrix);
+        matrix = new Matrix3f(rotation).mul(matrix);
         orientation = OrientationMapper.toId(matrix);
         setOrientation(orientation);
 
@@ -211,8 +211,8 @@ public class LittleToolHandler {
             int maxZ = minZ + cutoutSizeZ - oldSize.sizeZ;
 
             // Rotate cuboid
-            Vector3f v1 = positionRotation.transform(new Vector3f(minX, minY, minZ));
-            Vector3f v2 = positionRotation.transform(new Vector3f(maxX, maxY, maxZ));
+            Vector3f v1 = rotation.transform(new Vector3f(minX, minY, minZ));
+            Vector3f v2 = rotation.transform(new Vector3f(maxX, maxY, maxZ));
 
             // Save new start pos
             cutoutPosX = Math.round(Math.min(v1.x, v2.x));
@@ -233,7 +233,7 @@ public class LittleToolHandler {
             boolean negZ = nbt.getBoolean("cutoutNegZ");
 
             Vector3f negVec = new Vector3f(negX ? -1 : 1, negY ? -1 : 1, negZ ? -1 : 1);
-            negVec = orientationRotation.transform(negVec);
+            negVec = rotation.transform(negVec);
             negX = negVec.x < 0;
             negY = negVec.y < 0;
             negZ = negVec.z < 0;
@@ -247,8 +247,8 @@ public class LittleToolHandler {
             Vector3d faceStart = Plane3d.planes[faceStartI].getNormal();
             Vector3d faceEnd = Plane3d.planes[faceEndI].getNormal();
 
-            faceStart = new Vector3d(orientationRotation.transform(faceStart.toVector3f()));
-            faceEnd = new Vector3d(orientationRotation.transform(faceEnd.toVector3f()));
+            faceStart = new Vector3d(rotation.transform(faceStart.toVector3f()));
+            faceEnd = new Vector3d(rotation.transform(faceEnd.toVector3f()));
 
             faceStartI = getDirectionForNormal(faceStart).ordinal();
             faceEndI = getDirectionForNormal(faceEnd).ordinal();


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->

Depends on Depends on https://github.com/GTNewHorizons/LittleTiles/pull/138

Reworks the fix from #138 to work for multi block tiles as well.

<img width="1326" height="884" alt="image" src="https://github.com/user-attachments/assets/53e98d01-40f5-4ccc-845b-754ec9a705c0" />

Bottom left is the original
Top right is rotated without this PR
Top left is rotated with this PR


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge
