### PR TITLE
Fix multi preview

### DIFF
--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
@@ -250,7 +250,16 @@ public class LittleTilesBlockRenderHelper {
                 Mesh3d mesh = littleCube.renderCache == null ? null : littleCube.renderCache.getSimpleMesh();
                 if (mesh != null) {
                     mesh = mesh.copy();
+                    // Recipe meshes retain their multi-block position (for example, x = 1..2 for a tile in the
+                    // second block). Texture projection expects block-local coordinates; feeding those recipe-space
+                    // values to IIcon interpolation samples beyond the icon and into unrelated atlas sprites.
+                    Vector3d textureOffset = new Vector3d(
+                            Math.floor(cube.minX),
+                            Math.floor(cube.minY),
+                            Math.floor(cube.minZ));
+                    mesh.translate(new Vector3d(-textureOffset.x, -textureOffset.y, -textureOffset.z));
                     mesh.setTextures(block, metadata);
+                    mesh.translate(textureOffset);
                     boolean lightingWasEnabled = GL11.glIsEnabled(GL11.GL_LIGHTING);
                     GL11.glDisable(GL11.GL_LIGHTING);
                     GL11.glTranslatef(-0.5F, -0.5F, -0.5F);


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->

Depends on #138

Example is this tile on the floor:

<img width="570" height="552" alt="image" src="https://github.com/user-attachments/assets/cf7956d2-2f8d-4858-a07e-4f3c771609a5" />


Dropped item without this PR:

<img width="415" height="299" alt="image" src="https://github.com/user-attachments/assets/6e0a9de3-a988-4262-9b56-52802b1a8bd9" />

Dropped item with this PR:

<img width="570" height="552" alt="image" src="https://github.com/user-attachments/assets/73042f0f-7b5c-446a-8f33-1e44f7a6ca4c" />


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge
