### PR TITLE
Rework how cutoutInfo is passed

### DIFF
--- a/src/main/java/com/creativemd/littletiles/client/render/PreviewRenderer.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/PreviewRenderer.java
@@ -241,7 +241,7 @@ public class PreviewRenderer {
                         Vec3 color = previewTile.getPreviewColor();
 
                         LittleToolHandler toolHandler;
-                        if (previewTile.preview != null && mc.thePlayer.getHeldItem().getItem() != LittleTiles.chisel) {
+                        if (previewTile.preview != null) {
                             toolHandler = new LittleToolHandler(previewTile.preview.nbt);
                         } else {
                             toolHandler = new LittleToolHandler(mc.thePlayer.getHeldItem());

--- a/src/main/java/com/creativemd/littletiles/common/items/ItemBlockTiles.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemBlockTiles.java
@@ -29,7 +29,6 @@ import com.creativemd.littletiles.common.structure.LittleStructure;
 import com.creativemd.littletiles.common.utils.LittleTile;
 import com.creativemd.littletiles.common.utils.LittleTileBlock;
 import com.creativemd.littletiles.common.utils.LittleTileBlockPos;
-import com.creativemd.littletiles.common.utils.LittleTileCutoutInfo;
 import com.creativemd.littletiles.common.utils.LittleTilePlaceMode;
 import com.creativemd.littletiles.common.utils.LittleTilePreview;
 import com.creativemd.littletiles.common.utils.LittleToolHandler;
@@ -101,27 +100,18 @@ public class ItemBlockTiles extends ItemBlock implements ILittleTile, ITilesRend
 
         if (PreviewRenderer.markedHit != null) pos = PreviewRenderer.markedHit;
 
-        LittleTileCutoutInfo cutoutInfo = null;
-
         if (needsTwoHits(stack)) {
-            if (PreviewRenderer.firstHit == null) {
-                if (PreviewRenderer.markedHit == null) {
-                    PreviewRenderer.firstHit = pos;
-                    return true;
-                }
-                cutoutInfo = LittleTileCutoutInfo.fromItemStack(stack, pos, pos);
-            } else {
-                cutoutInfo = LittleTileCutoutInfo.fromItemStack(stack, PreviewRenderer.firstHit, pos);
-
-                ILittleTile littleTile = (ILittleTile) stack.getItem();
-
-                NBTTagCompound tag = (NBTTagCompound) littleTile.getLittlePreview(stack).get(0).nbt.copy();
-                stack = new ItemStack(Item.getItemFromBlock(LittleTiles.blockTile));
-                stack.stackTagCompound = tag;
-                PreviewRenderer.firstHit = null;
+            if (PreviewRenderer.firstHit == null && PreviewRenderer.markedHit == null) {
+                PreviewRenderer.firstHit = pos;
+                return true;
             }
-        } else {
-            cutoutInfo = LittleTileCutoutInfo.loadFromNBT(stack.stackTagCompound);
+
+            // The preview carries the cutout in its nbt, so the placed stack keeps it as well.
+            ILittleTile littleTile = (ILittleTile) stack.getItem();
+            NBTTagCompound tag = (NBTTagCompound) littleTile.getLittlePreview(stack).get(0).nbt.copy();
+            stack = new ItemStack(Item.getItemFromBlock(LittleTiles.blockTile));
+            stack.stackTagCompound = tag;
+            PreviewRenderer.firstHit = null;
         }
 
         x = pos.getPosX();
@@ -136,9 +126,9 @@ public class ItemBlockTiles extends ItemBlock implements ILittleTile, ITilesRend
             return false;
         } else {
             if (FMLCommonHandler.instance().getEffectiveSide() == Side.CLIENT) PacketHandler.sendPacketToServer(
-                    new LittlePlacePacket(stack, pos, PreviewRenderer.markedHit != null, cutoutInfo, placeMode));
+                    new LittlePlacePacket(stack, pos, PreviewRenderer.markedHit != null, placeMode));
 
-            placeBlockAt(player, stack, world, pos, PreviewRenderer.markedHit != null, cutoutInfo, placeMode);
+            placeBlockAt(player, stack, world, pos, PreviewRenderer.markedHit != null, placeMode);
 
             PreviewRenderer.markedHit = null;
 
@@ -177,9 +167,9 @@ public class ItemBlockTiles extends ItemBlock implements ILittleTile, ITilesRend
 
     public static boolean placeTiles(World world, EntityPlayer player, ArrayList<PreviewTile> previews,
             LittleStructure structure, int x, int y, int z, ItemStack stack, ArrayList<LittleTile> unplaceableTiles,
-            LittleTileCutoutInfo cutoutInfo, LittleTilePlaceMode placeMode) {
+            LittleTilePlaceMode placeMode) {
         LittleTilePlacementPlan plan = new LittleTilePlacementPlan();
-        plan.fillPlan(world, x, y, z, previews, structure, placeMode, cutoutInfo);
+        plan.fillPlan(world, x, y, z, previews, structure, placeMode);
         if (!plan.canApplyPlan()) {
             return false;
         }
@@ -188,7 +178,7 @@ public class ItemBlockTiles extends ItemBlock implements ILittleTile, ITilesRend
     }
 
     public boolean placeBlockAt(EntityPlayer player, ItemStack stack, World world, LittleTileBlockPos pos,
-            boolean customPlacement, LittleTileCutoutInfo cutoutInfo, LittleTilePlaceMode placeMode) {
+            boolean customPlacement, LittleTilePlaceMode placeMode) {
         ArrayList<PreviewTile> previews = PlacementHelper.getPreviewTiles(player, stack, pos, customPlacement);
 
         LittleStructure structure = null;
@@ -208,7 +198,7 @@ public class ItemBlockTiles extends ItemBlock implements ILittleTile, ITilesRend
         int z = pos.getPosZ();
 
         ArrayList<LittleTile> unplaceableTiles = new ArrayList<>();
-        if (placeTiles(world, player, previews, structure, x, y, z, stack, unplaceableTiles, cutoutInfo, placeMode)) {
+        if (placeTiles(world, player, previews, structure, x, y, z, stack, unplaceableTiles, placeMode)) {
             ItemStack currentStack = player.inventory.mainInventory[player.inventory.currentItem];
             boolean isChisel = currentStack != null && currentStack.getItem() == LittleTiles.chisel;
             if (!player.capabilities.isCreativeMode && !isChisel) {

--- a/src/main/java/com/creativemd/littletiles/common/items/ItemLittleChisel.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemLittleChisel.java
@@ -43,6 +43,7 @@ import com.creativemd.littletiles.common.utils.LittleTile;
 import com.creativemd.littletiles.common.utils.LittleTileBlock;
 import com.creativemd.littletiles.common.utils.LittleTileBlockColored;
 import com.creativemd.littletiles.common.utils.LittleTileBlockPos;
+import com.creativemd.littletiles.common.utils.LittleTileCutoutInfo;
 import com.creativemd.littletiles.common.utils.LittleTilePlaceMode;
 import com.creativemd.littletiles.common.utils.LittleTilePreview;
 import com.creativemd.littletiles.common.utils.LittleTileShapeMode;
@@ -115,28 +116,32 @@ public class ItemLittleChisel extends Item implements ILittleTile, IGuiHolder<Pl
 
         if (FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER) {
             size = new LittleTileSize(sizeX, sizeY, sizeZ);
-        } else if (PreviewRenderer.firstHit == null) {
-            size = new LittleTileSize(sizeX, sizeY, sizeZ);
         } else {
-            MovingObjectPosition moving = Minecraft.getMinecraft().objectMouseOver;
-            LittleTileBlockPos pos = null;
             int align = handler.getGrid();
-            if (moving != null) {
-                pos = LittleTileBlockPos.fromMovingObjectPosition(moving, align);
+            LittleTileBlockPos end = PreviewRenderer.markedHit;
+            if (end == null) {
+                MovingObjectPosition moving = Minecraft.getMinecraft().objectMouseOver;
+                if (moving == null) {
+                    return null;
+                }
+                end = LittleTileBlockPos.fromMovingObjectPosition(moving, align);
             }
-            if (PreviewRenderer.markedHit != null) {
-                pos = PreviewRenderer.markedHit;
-            }
-            if (pos == null) {
-                return null;
-            }
-            LittleTileBlockPos.Subtraction subtraction = pos.subtract(stack, PreviewRenderer.firstHit);
-            LittleTileBlockPos.Comparison comparison = PreviewRenderer.firstHit.compareTo(pos);
+            LittleTileBlockPos start = PreviewRenderer.firstHit != null ? PreviewRenderer.firstHit : end;
+
+            LittleTileBlockPos.Subtraction subtraction = end.subtract(stack, start);
+            LittleTileBlockPos.Comparison comparison = start.compareTo(end);
             size = new LittleTileSize(subtraction.x, subtraction.y, subtraction.z);
             nbt.setBoolean("fromChiselPosX", !comparison.biggerOrEqualX);
             nbt.setBoolean("fromChiselPosY", !comparison.biggerOrEqualY);
             nbt.setBoolean("fromChiselPosZ", !comparison.biggerOrEqualZ);
             nbt.setInteger("fromChiselAlign", align);
+
+            // The shape selected in the gui only becomes a concrete cutout once both hits are known,
+            // so it is written here, where the preview (and everything derived from it) picks it up.
+            LittleTileCutoutInfo cutoutInfo = LittleTileCutoutInfo.fromItemStack(stack, start, end);
+            if (cutoutInfo != null) {
+                cutoutInfo.writeToNBT(nbt);
+            }
         }
 
         LittleTile tile;

--- a/src/main/java/com/creativemd/littletiles/common/items/LittleTilePlacementPlan.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/LittleTilePlacementPlan.java
@@ -63,15 +63,14 @@ public class LittleTilePlacementPlan {
     private int originX;
     private int originY;
     private int originZ;
-    private LittleTileCutoutInfo cutoutInfo;
 
     public void fillPlan(World world, int x, int y, int z, ArrayList<PreviewTile> previews, LittleStructure structure,
-            LittleTilePlaceMode placeMode, LittleTileCutoutInfo cutoutInfo) {
+            LittleTilePlaceMode placeMode) {
         this.placeMode = placeMode;
         this.originX = x;
         this.originY = y;
         this.originZ = z;
-        this.cutoutInfo = cutoutInfo;
+
         if (previews.isEmpty()) {
             canApplyPlan = false;
             return;
@@ -174,8 +173,8 @@ public class LittleTilePlacementPlan {
 
     private boolean applyTile(PlacementEntry entry, PreviewTile placeTile, TileEntityLittleTiles tile,
             EntityPlayer player, ItemStack stack, LittleStructure structure, ArrayList<LittleTile> unplaceableTiles) {
-        LittleTileCutoutInfo baseCutoutInfo = getBaseCutoutInfo(placeTile, this.cutoutInfo);
-        LittleTileCutoutInfo cutoutInfoCurrent = getCutoutInfoCurrent(entry.coord, placeTile, this.cutoutInfo);
+        LittleTileCutoutInfo baseCutoutInfo = getBaseCutoutInfo(placeTile);
+        LittleTileCutoutInfo cutoutInfoCurrent = getCutoutInfoCurrent(entry.coord, placeTile);
         // Mesh-backed fragments can clip to empty space when split across blocks.
         // In that case we skip placement for this fragment instead of placing a full box tile.
         if (baseCutoutInfo != null && cutoutInfoCurrent == null) {
@@ -209,19 +208,15 @@ public class LittleTilePlacementPlan {
         return didPlace;
     }
 
-    private static LittleTileCutoutInfo getBaseCutoutInfo(PreviewTile placeTile, LittleTileCutoutInfo fallbackCutout) {
-        if (fallbackCutout != null) {
-            return new LittleTileCutoutInfo(fallbackCutout);
-        }
+    private static LittleTileCutoutInfo getBaseCutoutInfo(PreviewTile placeTile) {
         if (placeTile.preview != null && placeTile.preview.nbt != null) {
             return LittleTileCutoutInfo.loadFromNBT(placeTile.preview.nbt);
         }
         return null;
     }
 
-    private LittleTileCutoutInfo getCutoutInfoCurrent(ChunkCoordinates coord, PreviewTile placeTile,
-            LittleTileCutoutInfo cutoutInfo) {
-        LittleTileCutoutInfo cutoutInfoCurrent = getBaseCutoutInfo(placeTile, cutoutInfo);
+    private LittleTileCutoutInfo getCutoutInfoCurrent(ChunkCoordinates coord, PreviewTile placeTile) {
+        LittleTileCutoutInfo cutoutInfoCurrent = getBaseCutoutInfo(placeTile);
         if (cutoutInfoCurrent == null) {
             return null;
         }
@@ -287,10 +282,10 @@ public class LittleTilePlacementPlan {
         for (PreviewTile tile : placeTiles) {
             if (!tile.needsCollisionTest()) continue;
 
-            LittleTileCutoutInfo baseCutoutInfo = getBaseCutoutInfo(tile, cutoutInfo);
+            LittleTileCutoutInfo baseCutoutInfo = getBaseCutoutInfo(tile);
             LittleTileCutoutInfo perTileCutout = null;
             if (baseCutoutInfo != null) {
-                perTileCutout = getCutoutInfoCurrent(coord, tile, cutoutInfo);
+                perTileCutout = getCutoutInfoCurrent(coord, tile);
                 if (perTileCutout == null) {
                     continue;
                 }

--- a/src/main/java/com/creativemd/littletiles/common/packet/LittlePlacePacket.java
+++ b/src/main/java/com/creativemd/littletiles/common/packet/LittlePlacePacket.java
@@ -8,15 +8,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.network.play.server.S2FPacketSetSlot;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import org.joml.Vector3i;
-
 import com.creativemd.creativecore.common.packet.CreativeCorePacket;
 import com.creativemd.littletiles.LittleTiles;
 import com.creativemd.littletiles.common.items.ItemBlockTiles;
 import com.creativemd.littletiles.common.utils.LittleTileBlockPos;
-import com.creativemd.littletiles.common.utils.LittleTileCutoutInfo;
 import com.creativemd.littletiles.common.utils.LittleTilePlaceMode;
-import com.creativemd.littletiles.common.utils.LittleTileShapeMode;
 import com.creativemd.littletiles.common.utils.PlacementHelper;
 
 import cpw.mods.fml.common.network.ByteBufUtils;
@@ -31,18 +27,16 @@ public class LittlePlacePacket extends CreativeCorePacket {
     }
 
     public LittlePlacePacket(ItemStack stack, LittleTileBlockPos pos, boolean customPlacement,
-            LittleTileCutoutInfo cutoutInfo, LittleTilePlaceMode placeMode) {
+            LittleTilePlaceMode placeMode) {
         this.stack = stack;
         this.pos = pos;
         this.customPlacement = customPlacement;
-        this.cutoutInfo = cutoutInfo;
         this.placeMode = placeMode;
     }
 
     public ItemStack stack;
     public LittleTileBlockPos pos;
     public boolean customPlacement;
-    public LittleTileCutoutInfo cutoutInfo;
     public LittleTilePlaceMode placeMode;
 
     @Override
@@ -57,25 +51,6 @@ public class LittlePlacePacket extends CreativeCorePacket {
         buf.writeInt(pos.getSide().ordinal());
         buf.writeBoolean(customPlacement);
         buf.writeByte(placeMode.ordinal());
-        if (cutoutInfo == null) {
-            buf.writeBoolean(false);
-        } else {
-            buf.writeBoolean(true);
-            buf.writeInt(cutoutInfo.type.ordinal());
-            buf.writeInt(cutoutInfo.size.x);
-            buf.writeInt(cutoutInfo.size.y);
-            buf.writeInt(cutoutInfo.size.z);
-            buf.writeInt(cutoutInfo.pos.x);
-            buf.writeInt(cutoutInfo.pos.y);
-            buf.writeInt(cutoutInfo.pos.z);
-            buf.writeByte(cutoutInfo.orientation);
-            buf.writeByte(cutoutInfo.thickness);
-            buf.writeByte(cutoutInfo.faceStart.ordinal());
-            buf.writeByte(cutoutInfo.faceEnd.ordinal());
-            buf.writeBoolean(cutoutInfo.negX);
-            buf.writeBoolean(cutoutInfo.negY);
-            buf.writeBoolean(cutoutInfo.negZ);
-        }
     }
 
     @Override
@@ -91,25 +66,6 @@ public class LittlePlacePacket extends CreativeCorePacket {
         this.pos = new LittleTileBlockPos(posX, posY, posZ, subX, subY, subZ, ForgeDirection.getOrientation(side));
         this.customPlacement = buf.readBoolean();
         this.placeMode = LittleTilePlaceMode.fromOrdinal(buf.readByte());
-        if (buf.readBoolean()) {
-            this.cutoutInfo = new LittleTileCutoutInfo();
-            int cutoutInfo = buf.readInt();
-            this.cutoutInfo.type = LittleTileShapeMode.values()[cutoutInfo];
-            this.cutoutInfo.size.x = buf.readInt();
-            this.cutoutInfo.size.y = buf.readInt();
-            this.cutoutInfo.size.z = buf.readInt();
-            int cutoutPosX = buf.readInt();
-            int cutoutPosY = buf.readInt();
-            int cutoutPosZ = buf.readInt();
-            this.cutoutInfo.pos = new Vector3i(cutoutPosX, cutoutPosY, cutoutPosZ);
-            this.cutoutInfo.orientation = buf.readByte();
-            this.cutoutInfo.thickness = buf.readByte();
-            this.cutoutInfo.faceStart = ForgeDirection.values()[buf.readByte()];
-            this.cutoutInfo.faceEnd = ForgeDirection.values()[buf.readByte()];
-            this.cutoutInfo.negX = buf.readBoolean();
-            this.cutoutInfo.negY = buf.readBoolean();
-            this.cutoutInfo.negZ = buf.readBoolean();
-        }
     }
 
     @Override
@@ -122,7 +78,7 @@ public class LittlePlacePacket extends CreativeCorePacket {
     public void executeServer(EntityPlayer player) {
         if (PlacementHelper.isLittleBlock(stack)) {
             ((ItemBlockTiles) Item.getItemFromBlock(LittleTiles.blockTile))
-                    .placeBlockAt(player, stack, player.worldObj, pos, customPlacement, cutoutInfo, placeMode);
+                    .placeBlockAt(player, stack, player.worldObj, pos, customPlacement, placeMode);
 
             EntityPlayerMP playerMP = (EntityPlayerMP) player;
             Slot slot = playerMP.openContainer.getSlotFromInventory(playerMP.inventory, playerMP.inventory.currentItem);

--- a/src/main/java/com/creativemd/littletiles/common/structure/LittleDoor.java
+++ b/src/main/java/com/creativemd/littletiles/common/structure/LittleDoor.java
@@ -284,18 +284,8 @@ public class LittleDoor extends LittleStructure {
          * structure.normalAxis = Axis.AxisY; break; default: break; }
          */
 
-        if (ItemBlockTiles.placeTiles(
-                world,
-                player,
-                previews,
-                structure,
-                x,
-                y,
-                z,
-                null,
-                null,
-                null,
-                LittleTilePlaceMode.NORMAL)) {
+        if (ItemBlockTiles
+                .placeTiles(world, player, previews, structure, x, y, z, null, null, LittleTilePlaceMode.NORMAL)) {
             ArrayList<LittleTile> tiles = getTiles();
             for (LittleTile littleTile : tiles) {
                 littleTile.te.update();


### PR DESCRIPTION
## Summary
This PR is only a refactor. It's aim is to cleanup the architecture around "cutoutInfo" and how it's passed, removing a bunch of branches and reducing complexity.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
