### PR TITLE
Rework rendercache to not require tiles for meshes

### DIFF
--- a/src/main/java/com/creativemd/littletiles/common/items/ItemBlockTiles.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemBlockTiles.java
@@ -34,9 +34,6 @@ import com.creativemd.littletiles.common.utils.LittleTilePlaceMode;
 import com.creativemd.littletiles.common.utils.LittleTilePreview;
 import com.creativemd.littletiles.common.utils.LittleToolHandler;
 import com.creativemd.littletiles.common.utils.PlacementHelper;
-import com.creativemd.littletiles.common.utils.small.LittleTileBox;
-import com.creativemd.littletiles.common.utils.small.LittleTileSize;
-import com.creativemd.littletiles.common.utils.small.LittleTileVec;
 import com.creativemd.littletiles.utils.PreviewTile;
 
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -252,21 +249,10 @@ public class ItemBlockTiles extends ItemBlock implements ILittleTile, ITilesRend
     public ArrayList<CubeObject> getRenderingCubes(ItemStack stack) {
         ArrayList<CubeObject> cubes = new ArrayList<>();
         if (!stack.hasTagCompound()) return cubes;
-        LittleTile tile = LittleTile.CreateandLoadTile(null, null, stack.stackTagCompound);
-        if (tile != null) {
-            cubes.addAll(tile.getRenderingCubes());
-            return cubes;
-        }
-        Block block = Block.getBlockFromName(stack.stackTagCompound.getString("block"));
-        int meta = stack.stackTagCompound.getInteger("meta");
-        LittleTileSize size = new LittleTileSize("size", stack.stackTagCompound);
-        if (!(block instanceof BlockAir)) {
-            CubeObject cube = new LittleTileBox(new LittleTileVec(8, 8, 8), size, true).getCube();
-            cube.block = block;
-            cube.meta = meta;
-            if (stack.stackTagCompound.hasKey("color")) cube.color = stack.stackTagCompound.getInteger("color");
-            cubes.add(cube);
-        }
+        LittleTilePreview preview = LittleTilePreview.getPreviewFromNBT(stack.stackTagCompound);
+        if (preview == null) return cubes;
+        CubeObject cube = preview.getCubeBlock();
+        if (!(cube.block instanceof BlockAir)) cubes.add(cube);
         return cubes;
     }
 

--- a/src/main/java/com/creativemd/littletiles/common/items/ItemRecipe.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemRecipe.java
@@ -227,15 +227,6 @@ public class ItemRecipe extends Item implements ITilesRenderer, IGuiCreator {
         ArrayList<CubeObject> cubes = new ArrayList<>();
         if (preview != null) {
             for (LittleTilePreview littleTilePreview : preview) {
-                try {
-                    LittleTile tile = LittleTile.CreateandLoadTile(null, null, littleTilePreview.nbt);
-                    if (tile != null) {
-                        cubes.addAll(tile.getRenderingCubes());
-                        continue;
-                    }
-                } catch (Exception ignored) {
-
-                }
                 cubes.add(littleTilePreview.getCubeBlock());
             }
         }

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTile.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTile.java
@@ -122,7 +122,7 @@ public abstract class LittleTile {
 
     private LittleTileCutoutInfo cutoutInfo = null;
 
-    private final LittleTileRenderCache renderCache = new LittleTileRenderCache(this);
+    private final LittleTileRenderCache renderCache = new LittleTileRenderCache(() -> boundingBox, () -> cutoutInfo);
 
     public AxisAlignedBB getSelectedBox() {
         if (boundingBox != null) {

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTilePreview.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTilePreview.java
@@ -11,6 +11,7 @@ import com.creativemd.creativecore.common.utils.CubeObject;
 import com.creativemd.littletiles.common.tileentity.TileEntityLittleTiles;
 import com.creativemd.littletiles.common.utils.small.LittleTileBox;
 import com.creativemd.littletiles.common.utils.small.LittleTileSize;
+import com.creativemd.littletiles.common.utils.small.LittleTileVec;
 import com.creativemd.littletiles.utils.ShiftHandler;
 
 public final class LittleTilePreview {
@@ -43,13 +44,16 @@ public final class LittleTilePreview {
     }
 
     public CubeObject getCubeBlock() {
-        CubeObject cube = box.getCube();
+        LittleTileBox renderBox = box != null ? box : new LittleTileBox(new LittleTileVec(8, 8, 8), size, true);
+        LittleTilesCubeObject cube = renderBox.getCube();
         if (nbt.hasKey("block")) {
             cube.block = Block.getBlockFromName(nbt.getString("block"));
             cube.meta = nbt.getInteger("meta");
         } else {
             cube.block = Blocks.stone;
         }
+        cube.cutoutInfo = LittleTileCutoutInfo.loadFromNBT(nbt);
+        cube.renderCache = new LittleTileRenderCache(() -> renderBox, () -> cube.cutoutInfo);
         if (nbt.hasKey("color")) cube.color = nbt.getInteger("color");
         return cube;
     }

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTileRenderCache.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTileRenderCache.java
@@ -1,19 +1,22 @@
 package com.creativemd.littletiles.common.utils;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.creativemd.littletiles.client.util3d.Mesh3d;
 import com.creativemd.littletiles.client.util3d.Mesh3dUtil;
 import com.creativemd.littletiles.client.util3d.Triangle3d;
+import com.creativemd.littletiles.common.utils.small.LittleTileBox;
 
 /**
  * Client render geometry retained for a little tile.
  */
 public class LittleTileRenderCache {
 
-    private final LittleTile tile;
+    private final Supplier<LittleTileBox> boxGetter;
+    private final Supplier<LittleTileCutoutInfo> cutoutGetter;
     private volatile Mesh3d simpleMesh;
 
     private volatile List<Triangle3d> visibleCutoutTriangles;
@@ -22,16 +25,19 @@ public class LittleTileRenderCache {
     /** Bit set of {@link ForgeDirection#ordinal()}: the sides drawn as triangles instead of as rectangles. */
     private int replacedBoxSides;
 
-    public LittleTileRenderCache(LittleTile tile) {
-        this.tile = tile;
+    public LittleTileRenderCache(Supplier<LittleTileBox> boxGetter, Supplier<LittleTileCutoutInfo> cutoutGetter) {
+        this.boxGetter = boxGetter;
+        this.cutoutGetter = cutoutGetter;
     }
 
     public Mesh3d getSimpleMesh() {
-        if (tile.getCutoutInfo() == null || tile.boundingBox == null) {
+        LittleTileBox box = boxGetter.get();
+        LittleTileCutoutInfo cutoutInfo = cutoutGetter.get();
+        if (cutoutInfo == null || box == null) {
             return null;
         }
         if (simpleMesh == null) {
-            simpleMesh = Mesh3dUtil.meshFromTile(tile.boundingBox, tile.getCutoutInfo());
+            simpleMesh = Mesh3dUtil.meshFromTile(box, cutoutInfo);
         }
         return simpleMesh;
     }


### PR DESCRIPTION
## Summary
Another cleanup PR. This time to simplify the way meshes are generated, to avoid temporary tile creation


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [] This PR requires another PR in order to merge
