### PR TITLE
Fix collision handling to detect overlapping slopes

### DIFF
--- a/src/main/java/com/creativemd/littletiles/client/util3d/TriangleTriangleIntersect.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/TriangleTriangleIntersect.java
@@ -229,7 +229,7 @@ public class TriangleTriangleIntersect {
         sort(isect2);
 
         // Treat endpoint contact as non-overlap. This allows complementary slopes to touch without blocking placement.
-        if (isect1[1] <= isect2[0] + EPSILON || isect2[1] <= isect1[0] + EPSILON) {
+        if (isect1[1] <= isect2[0] || isect2[1] <= isect1[0]) {
             return false;
         }
 


### PR DESCRIPTION
## Summary
Fixes a collision edge case with slopes:

<img width="1175" height="630" alt="image" src="https://github.com/user-attachments/assets/d32105cf-b501-4217-918a-9fd88b510a98" />

With this PR that issue is fixed. While hopefully still allowing slopes to exactly touch each other and boxes.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
