### PR TITLE
Chisel GUI improvements: Shape preview and better block picker

### DIFF
--- a/src/main/java/com/creativemd/littletiles/client/util3d/Mesh3dUtil.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/Mesh3dUtil.java
@@ -160,24 +160,24 @@ public class Mesh3dUtil {
     }
 
     public static Mesh3d createBoxMesh() {
-            List<Triangle3d> triangles = new ArrayList<>();
+        List<Triangle3d> triangles = new ArrayList<>();
 
-            triangles.add(new Triangle3d(new Vector3d(0, 0, 1), new Vector3d(1, 0, 1), new Vector3d(1, 1, 1)));
-            triangles.add(new Triangle3d(new Vector3d(0, 0, 1), new Vector3d(1, 1, 1), new Vector3d(0, 1, 1)));
-            triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(1, 1, 0), new Vector3d(1, 0, 0)));
-            triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(0, 1, 0), new Vector3d(1, 1, 0)));
-            triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(0, 0, 1), new Vector3d(0, 1, 1)));
-            triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(0, 1, 1), new Vector3d(0, 1, 0)));
-            triangles.add(new Triangle3d(new Vector3d(1, 0, 0), new Vector3d(1, 1, 1), new Vector3d(1, 0, 1)));
-            triangles.add(new Triangle3d(new Vector3d(1, 0, 0), new Vector3d(1, 1, 0), new Vector3d(1, 1, 1)));
-            triangles.add(new Triangle3d(new Vector3d(0, 1, 0), new Vector3d(0, 1, 1), new Vector3d(1, 1, 1)));
-            triangles.add(new Triangle3d(new Vector3d(0, 1, 0), new Vector3d(1, 1, 1), new Vector3d(1, 1, 0)));
-            triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(1, 0, 1), new Vector3d(0, 0, 1)));
-            triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(1, 0, 0), new Vector3d(1, 0, 1)));
+        triangles.add(new Triangle3d(new Vector3d(0, 0, 1), new Vector3d(1, 0, 1), new Vector3d(1, 1, 1)));
+        triangles.add(new Triangle3d(new Vector3d(0, 0, 1), new Vector3d(1, 1, 1), new Vector3d(0, 1, 1)));
+        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(1, 1, 0), new Vector3d(1, 0, 0)));
+        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(0, 1, 0), new Vector3d(1, 1, 0)));
+        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(0, 0, 1), new Vector3d(0, 1, 1)));
+        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(0, 1, 1), new Vector3d(0, 1, 0)));
+        triangles.add(new Triangle3d(new Vector3d(1, 0, 0), new Vector3d(1, 1, 1), new Vector3d(1, 0, 1)));
+        triangles.add(new Triangle3d(new Vector3d(1, 0, 0), new Vector3d(1, 1, 0), new Vector3d(1, 1, 1)));
+        triangles.add(new Triangle3d(new Vector3d(0, 1, 0), new Vector3d(0, 1, 1), new Vector3d(1, 1, 1)));
+        triangles.add(new Triangle3d(new Vector3d(0, 1, 0), new Vector3d(1, 1, 1), new Vector3d(1, 1, 0)));
+        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(1, 0, 1), new Vector3d(0, 0, 1)));
+        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(1, 0, 0), new Vector3d(1, 0, 1)));
 
-            Mesh3d mesh = new Mesh3d(triangles);
-            return mesh;
-        }
+        Mesh3d mesh = new Mesh3d(triangles);
+        return mesh;
+    }
 
     public static Mesh3d createMesh(LittleTileCutoutInfo cutoutInfo, Vector3d cutoutScale, Vector3d pos,
             Vector3i posCutout, Vector3i posSubMin, Vector3i posSubMax, Block block, int meta, int orientation) {

--- a/src/main/java/com/creativemd/littletiles/client/util3d/Mesh3dUtil.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/Mesh3dUtil.java
@@ -159,6 +159,26 @@ public class Mesh3dUtil {
         return mesh;
     }
 
+    public static Mesh3d createBoxMesh() {
+            List<Triangle3d> triangles = new ArrayList<>();
+
+            triangles.add(new Triangle3d(new Vector3d(0, 0, 1), new Vector3d(1, 0, 1), new Vector3d(1, 1, 1)));
+            triangles.add(new Triangle3d(new Vector3d(0, 0, 1), new Vector3d(1, 1, 1), new Vector3d(0, 1, 1)));
+            triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(1, 1, 0), new Vector3d(1, 0, 0)));
+            triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(0, 1, 0), new Vector3d(1, 1, 0)));
+            triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(0, 0, 1), new Vector3d(0, 1, 1)));
+            triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(0, 1, 1), new Vector3d(0, 1, 0)));
+            triangles.add(new Triangle3d(new Vector3d(1, 0, 0), new Vector3d(1, 1, 1), new Vector3d(1, 0, 1)));
+            triangles.add(new Triangle3d(new Vector3d(1, 0, 0), new Vector3d(1, 1, 0), new Vector3d(1, 1, 1)));
+            triangles.add(new Triangle3d(new Vector3d(0, 1, 0), new Vector3d(0, 1, 1), new Vector3d(1, 1, 1)));
+            triangles.add(new Triangle3d(new Vector3d(0, 1, 0), new Vector3d(1, 1, 1), new Vector3d(1, 1, 0)));
+            triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(1, 0, 1), new Vector3d(0, 0, 1)));
+            triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(1, 0, 0), new Vector3d(1, 0, 1)));
+
+            Mesh3d mesh = new Mesh3d(triangles);
+            return mesh;
+        }
+
     public static Mesh3d createMesh(LittleTileCutoutInfo cutoutInfo, Vector3d cutoutScale, Vector3d pos,
             Vector3i posCutout, Vector3i posSubMin, Vector3i posSubMax, Block block, int meta, int orientation) {
         Mesh3d mesh = switch (cutoutInfo.type) {

--- a/src/main/java/com/creativemd/littletiles/common/gui/BlockDisplayWidget.java
+++ b/src/main/java/com/creativemd/littletiles/common/gui/BlockDisplayWidget.java
@@ -43,6 +43,8 @@ public class BlockDisplayWidget extends SingleChildWidget<BlockDisplayWidget> im
     private final BlockStateSyncValue syncBlock;
     private final boolean isClient;
 
+    public static final int WIDGET_MARGIN = 5;
+
     public BlockDisplayWidget(PanelSyncManager syncManager, BlockStateSyncValue syncBlock) {
         menu.setEnabled(false);
         menu.background(GuiTextures.BUTTON_CLEAN);
@@ -125,9 +127,9 @@ public class BlockDisplayWidget extends SingleChildWidget<BlockDisplayWidget> im
 
         int arrowSize = smallerSide / 2;
         if (menu.isOpen()) {
-            arrowOpened.draw(context, area.width - arrowSize, arrowSize / 2, arrowSize, arrowSize, theme);
+            arrowOpened.draw(context, area.width - arrowSize - 5, arrowSize / 2, arrowSize, arrowSize, theme);
         } else {
-            arrowClosed.draw(context, area.width - arrowSize, arrowSize / 2, arrowSize, arrowSize, theme);
+            arrowClosed.draw(context, area.width - arrowSize - 5, arrowSize / 2, arrowSize, arrowSize, theme);
         }
     }
 
@@ -175,32 +177,41 @@ public class BlockDisplayWidget extends SingleChildWidget<BlockDisplayWidget> im
 
     private static class DropDownWrapper extends ScrollWidget<BlockDisplayWidget.DropDownWrapper> {
 
+        private static final int SEARCH_ROW_HEIGHT = 20;
+        private static final int SEARCH_LABEL_WIDTH = 52;
+        private static final int SCROLL_ROWS = 4;
+        private static final int DROPDOWN_HEIGHT = 145;
+
         private final List<ButtonWidget<?>> children = new ArrayList<>();
         private boolean open;
         private int count = 0;
         private int currentIndex = -1;
-        ScrollWidget<?> scroll = new ScrollWidget<>(new VerticalScrollData());
-        TextFieldWidget text_search = new TextFieldWidget();
-        TextWidget<?> label_search = IKey.lang("key.littletiles.search").asWidget();
-        ParentWidget<?> panel = new ParentWidget<>();
+
+        private final ScrollWidget<?> scroll = new ScrollWidget<>(new VerticalScrollData());
+        private final TextFieldWidget text_search = new TextFieldWidget();
+        private final TextWidget<?> label_search = IKey.lang("key.littletiles.search").asWidget();
+        private final ParentWidget<?> panel = new ParentWidget<>();
+        private final Flow flow = new Flow(GuiAxis.X);
         private final List<ItemStack> stacks;
-        int visibleSize = 0;
+        private int visibleSize = 0;
         private String lastFilter;
 
         public DropDownWrapper(List<ItemStack> stacks) {
             this.stacks = stacks;
 
-            Flow flow = new Flow(GuiAxis.X);
-            flow.pos(5, 5);
-            flow.size(100, 20);
-            panel.size(200, 150);
-            text_search.marginLeft(5).width(100);
+            flow.pos(WIDGET_MARGIN, WIDGET_MARGIN);
+            flow.size(1, SEARCH_ROW_HEIGHT);
+
+            label_search.width(SEARCH_LABEL_WIDTH);
+            text_search.marginLeft(WIDGET_MARGIN).marginRight(WIDGET_MARGIN);
+
             flow.addChild(label_search, 0);
             flow.addChild(text_search, 1);
             panel.addChild(flow, 0);
             panel.addChild(scroll, 1);
-            scroll.pos(5, 40);
-            scroll.size(scrollWidth * 18 + 5, 4 * 18);
+
+            scroll.pos(WIDGET_MARGIN, WIDGET_MARGIN * 2 + SEARCH_ROW_HEIGHT);
+            scroll.size(1, SCROLL_ROWS * 18);
 
             text_search.onUpdateListener(x -> updateFilter());
         }
@@ -281,9 +292,22 @@ public class BlockDisplayWidget extends SingleChildWidget<BlockDisplayWidget> im
         public void onResized() {
             super.onResized();
             if (!isValid()) return;
+
+            int width = Math.max(getParentArea().width, scrollWidth * 18 + 2 * WIDGET_MARGIN);
+            int minContentHeight = WIDGET_MARGIN * 3 + SEARCH_ROW_HEIGHT + SCROLL_ROWS * 18;
+            int dropdownHeight = Math.max(DROPDOWN_HEIGHT, minContentHeight);
+            int scrollHeight = dropdownHeight - (WIDGET_MARGIN * 3 + SEARCH_ROW_HEIGHT);
+
+            flow.pos(WIDGET_MARGIN, WIDGET_MARGIN);
+            flow.size(Math.max(1, width - 2 * WIDGET_MARGIN), SEARCH_ROW_HEIGHT);
+            text_search.width(Math.max(1, width - 2 * WIDGET_MARGIN - SEARCH_LABEL_WIDTH - WIDGET_MARGIN));
+
+            scroll.pos(WIDGET_MARGIN, WIDGET_MARGIN * 2 + SEARCH_ROW_HEIGHT);
+            scroll.size(Math.max(1, width - 2 * WIDGET_MARGIN), scrollHeight);
             scroll.getScrollArea().getScrollY().setScrollSize((visibleSize + scrollWidth - 1) / scrollWidth * 18);
 
-            size(scrollWidth * 18 + 18, 9 * 18);
+            panel.size(width, dropdownHeight);
+            size(width, dropdownHeight);
             pos(0, getParentArea().height);
 
             List<IWidget> children = getChildren();

--- a/src/main/java/com/creativemd/littletiles/common/gui/ShapeSelectorWidget.java
+++ b/src/main/java/com/creativemd/littletiles/common/gui/ShapeSelectorWidget.java
@@ -7,8 +7,8 @@ import java.util.Map;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderHelper;
-import net.minecraft.init.Blocks;
 import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.init.Blocks;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.joml.Vector3i;
@@ -125,10 +125,20 @@ public class ShapeSelectorWidget extends SingleChildWidget<ShapeSelectorWidget> 
 
         int arrowSize = smallerSide / 2;
         if (menu.isOpen()) {
-            arrowOpened.draw(context, area.width - arrowSize, arrowSize / 2, arrowSize, arrowSize,
+            arrowOpened.draw(
+                    context,
+                    area.width - arrowSize,
+                    arrowSize / 2,
+                    arrowSize,
+                    arrowSize,
                     getWidgetTheme(context.getTheme()).getTheme());
         } else {
-            arrowClosed.draw(context, area.width - arrowSize, arrowSize / 2, arrowSize, arrowSize,
+            arrowClosed.draw(
+                    context,
+                    area.width - arrowSize,
+                    arrowSize / 2,
+                    arrowSize,
+                    arrowSize,
                     getWidgetTheme(context.getTheme()).getTheme());
         }
     }
@@ -163,14 +173,14 @@ public class ShapeSelectorWidget extends SingleChildWidget<ShapeSelectorWidget> 
             cutoutInfo.thickness = 5;
             cutoutInfo.faceStart = ForgeDirection.SOUTH;
             cutoutInfo.faceEnd = ForgeDirection.UP;
-            Mesh3d mesh = Mesh3dUtil.createMesh(cutoutInfo, new Vector3d(1, 1, 1), new Vector3d(), ZERO, ZERO, FULL_TILE,
-                    null, 0, 0);
+            Mesh3d mesh = Mesh3dUtil
+                    .createMesh(cutoutInfo, new Vector3d(1, 1, 1), new Vector3d(), ZERO, ZERO, FULL_TILE, null, 0, 0);
             mesh.setTextures(Blocks.quartz_block, 0);
             return mesh;
         }
 
-        Mesh3d mesh = Mesh3dUtil.createMesh(cutoutInfo, new Vector3d(1, 1, 1), new Vector3d(), ZERO, ZERO, FULL_TILE,
-            null, 0, 0);
+        Mesh3d mesh = Mesh3dUtil
+                .createMesh(cutoutInfo, new Vector3d(1, 1, 1), new Vector3d(), ZERO, ZERO, FULL_TILE, null, 0, 0);
         mesh.setTextures(Blocks.quartz_block, 0);
         return mesh;
     }

--- a/src/main/java/com/creativemd/littletiles/common/gui/ShapeSelectorWidget.java
+++ b/src/main/java/com/creativemd/littletiles/common/gui/ShapeSelectorWidget.java
@@ -127,7 +127,7 @@ public class ShapeSelectorWidget extends SingleChildWidget<ShapeSelectorWidget> 
         IDrawable currentArrow = menu.isOpen() ? arrowOpened : arrowClosed;
         currentArrow.draw(
                 context,
-                area.width - arrowSize,
+                area.width - arrowSize - 5,
                 arrowSize / 2,
                 arrowSize,
                 arrowSize,

--- a/src/main/java/com/creativemd/littletiles/common/gui/ShapeSelectorWidget.java
+++ b/src/main/java/com/creativemd/littletiles/common/gui/ShapeSelectorWidget.java
@@ -145,13 +145,14 @@ public class ShapeSelectorWidget extends SingleChildWidget<ShapeSelectorWidget> 
         if (mesh == null) {
             mesh = createPreviewMesh(shape);
             PREVIEW_MESHES.put(shape, mesh);
+            mesh.setTextures(Blocks.quartz_block, 0);
         }
         return mesh;
     }
 
     private static Mesh3d createPreviewMesh(LittleTileShapeMode shape) {
         if (shape == LittleTileShapeMode.BOX) {
-            return createBoxMesh();
+            return Mesh3dUtil.createBoxMesh();
         }
 
         LittleTileCutoutInfo cutoutInfo = new LittleTileCutoutInfo();
@@ -166,34 +167,11 @@ public class ShapeSelectorWidget extends SingleChildWidget<ShapeSelectorWidget> 
             cutoutInfo.faceEnd = ForgeDirection.UP;
             Mesh3d mesh = Mesh3dUtil
                     .createMesh(cutoutInfo, new Vector3d(1, 1, 1), new Vector3d(), ZERO, ZERO, FULL_TILE, null, 0, 0);
-            mesh.setTextures(Blocks.quartz_block, 0);
             return mesh;
         }
 
         Mesh3d mesh = Mesh3dUtil
                 .createMesh(cutoutInfo, new Vector3d(1, 1, 1), new Vector3d(), ZERO, ZERO, FULL_TILE, null, 0, 0);
-        mesh.setTextures(Blocks.quartz_block, 0);
-        return mesh;
-    }
-
-    private static Mesh3d createBoxMesh() {
-        List<Triangle3d> triangles = new ArrayList<>();
-
-        triangles.add(new Triangle3d(new Vector3d(0, 0, 1), new Vector3d(1, 0, 1), new Vector3d(1, 1, 1)));
-        triangles.add(new Triangle3d(new Vector3d(0, 0, 1), new Vector3d(1, 1, 1), new Vector3d(0, 1, 1)));
-        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(1, 1, 0), new Vector3d(1, 0, 0)));
-        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(0, 1, 0), new Vector3d(1, 1, 0)));
-        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(0, 0, 1), new Vector3d(0, 1, 1)));
-        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(0, 1, 1), new Vector3d(0, 1, 0)));
-        triangles.add(new Triangle3d(new Vector3d(1, 0, 0), new Vector3d(1, 1, 1), new Vector3d(1, 0, 1)));
-        triangles.add(new Triangle3d(new Vector3d(1, 0, 0), new Vector3d(1, 1, 0), new Vector3d(1, 1, 1)));
-        triangles.add(new Triangle3d(new Vector3d(0, 1, 0), new Vector3d(0, 1, 1), new Vector3d(1, 1, 1)));
-        triangles.add(new Triangle3d(new Vector3d(0, 1, 0), new Vector3d(1, 1, 1), new Vector3d(1, 1, 0)));
-        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(1, 0, 1), new Vector3d(0, 0, 1)));
-        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(1, 0, 0), new Vector3d(1, 0, 1)));
-
-        Mesh3d mesh = new Mesh3d(triangles);
-        mesh.setTextures(Blocks.quartz_block, 0);
         return mesh;
     }
 

--- a/src/main/java/com/creativemd/littletiles/common/gui/ShapeSelectorWidget.java
+++ b/src/main/java/com/creativemd/littletiles/common/gui/ShapeSelectorWidget.java
@@ -124,23 +124,14 @@ public class ShapeSelectorWidget extends SingleChildWidget<ShapeSelectorWidget> 
         }
 
         int arrowSize = smallerSide / 2;
-        if (menu.isOpen()) {
-            arrowOpened.draw(
-                    context,
-                    area.width - arrowSize,
-                    arrowSize / 2,
-                    arrowSize,
-                    arrowSize,
-                    getWidgetTheme(context.getTheme()).getTheme());
-        } else {
-            arrowClosed.draw(
-                    context,
-                    area.width - arrowSize,
-                    arrowSize / 2,
-                    arrowSize,
-                    arrowSize,
-                    getWidgetTheme(context.getTheme()).getTheme());
-        }
+        IDrawable currentArrow = menu.isOpen() ? arrowOpened : arrowClosed;
+        currentArrow.draw(
+                context,
+                area.width - arrowSize,
+                arrowSize / 2,
+                arrowSize,
+                arrowSize,
+                getWidgetTheme(context.getTheme()).getTheme());
     }
 
     @Override
@@ -166,7 +157,7 @@ public class ShapeSelectorWidget extends SingleChildWidget<ShapeSelectorWidget> 
         LittleTileCutoutInfo cutoutInfo = new LittleTileCutoutInfo();
         cutoutInfo.type = shape;
         cutoutInfo.size = new Vector3i(FULL_TILE);
-        cutoutInfo.pos = new Vector3i();
+        cutoutInfo.pos = ZERO;
         cutoutInfo.orientation = 0;
 
         if (shape == LittleTileShapeMode.PILLAR) {
@@ -256,15 +247,13 @@ public class ShapeSelectorWidget extends SingleChildWidget<ShapeSelectorWidget> 
         GL11.glVertex3d(point.x, point.y, point.z);
     }
 
-    private static class ShapePreviewWidget extends TextWidget {
+    private static class ShapePreviewWidget extends TextWidget<ShapePreviewWidget> {
 
         private final LittleTileShapeMode shape;
-        private final IKey label;
 
         public ShapePreviewWidget(LittleTileShapeMode shape) {
             super(IKey.str(shape.getName()));
             this.shape = shape;
-            this.label = IKey.str(shape.getName());
         }
 
         @Override
@@ -274,7 +263,7 @@ public class ShapeSelectorWidget extends SingleChildWidget<ShapeSelectorWidget> 
             int previewX = 3;
             int previewY = Math.max(0, (area.height - PREVIEW_SIZE) / 2);
             drawTexturedPreview(getPreviewMesh(shape), previewX, previewY, PREVIEW_SIZE);
-            label.draw(context, PREVIEW_SIZE + 8, 0, 0, area.height, theme);
+            getKey().draw(context, PREVIEW_SIZE + 8, 0, 0, area.height, theme);
         }
     }
 

--- a/src/main/java/com/creativemd/littletiles/common/gui/ShapeSelectorWidget.java
+++ b/src/main/java/com/creativemd/littletiles/common/gui/ShapeSelectorWidget.java
@@ -1,0 +1,367 @@
+package com.creativemd.littletiles.common.gui;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.init.Blocks;
+import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import org.joml.Vector3i;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
+
+import com.cleanroommc.modularui.api.drawable.IDrawable;
+import com.cleanroommc.modularui.api.drawable.IKey;
+import com.cleanroommc.modularui.api.widget.IWidget;
+import com.cleanroommc.modularui.api.widget.Interactable;
+import com.cleanroommc.modularui.drawable.GuiTextures;
+import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
+import com.cleanroommc.modularui.theme.WidgetTheme;
+import com.cleanroommc.modularui.theme.WidgetThemeEntry;
+import com.cleanroommc.modularui.widget.ParentWidget;
+import com.cleanroommc.modularui.widget.ScrollWidget;
+import com.cleanroommc.modularui.widget.SingleChildWidget;
+import com.cleanroommc.modularui.widget.WidgetTree;
+import com.cleanroommc.modularui.widget.scroll.VerticalScrollData;
+import com.cleanroommc.modularui.widget.sizer.Area;
+import com.cleanroommc.modularui.widgets.ButtonWidget;
+import com.cleanroommc.modularui.widgets.TextWidget;
+import com.creativemd.creativecore.lib.Vector3d;
+import com.creativemd.littletiles.client.util3d.Mesh3d;
+import com.creativemd.littletiles.client.util3d.Mesh3dUtil;
+import com.creativemd.littletiles.client.util3d.Triangle3d;
+import com.creativemd.littletiles.common.utils.LittleTileCutoutInfo;
+import com.creativemd.littletiles.common.utils.LittleTileShapeMode;
+
+public class ShapeSelectorWidget extends SingleChildWidget<ShapeSelectorWidget> implements Interactable {
+
+    private static final int ROW_HEIGHT = 20;
+    private static final int VISIBLE_ROWS = 8;
+    private static final int PREVIEW_SIZE = 14;
+    private static final int ROW_CONTENT_GUTTER = 12;
+    private static final Vector3i FULL_TILE = new Vector3i(16, 16, 16);
+    private static final Vector3i ZERO = new Vector3i();
+    private static final Map<LittleTileShapeMode, Mesh3d> PREVIEW_MESHES = new EnumMap<>(LittleTileShapeMode.class);
+
+    private IDrawable arrowClosed;
+    private IDrawable arrowOpened;
+    private final DropDownWrapper menu = new DropDownWrapper();
+
+    public ShapeSelectorWidget() {
+        menu.setEnabled(false);
+        menu.background(GuiTextures.BUTTON_CLEAN);
+        child(menu);
+        setArrows(GuiTextures.ARROW_UP, GuiTextures.ARROW_DOWN);
+    }
+
+    public int getSelectedIndex() {
+        return menu.getCurrentIndex();
+    }
+
+    public ShapeSelectorWidget setSelectedIndex(int index) {
+        menu.setCurrentIndex(index);
+        return getThis();
+    }
+
+    public ShapeSelectorWidget setArrows(IDrawable closed, IDrawable opened) {
+        this.arrowClosed = closed;
+        this.arrowOpened = opened;
+        return getThis();
+    }
+
+    public ShapeSelectorWidget addChoice(ShapeSelected onSelect, LittleTileShapeMode shape) {
+        ButtonWidget<?> button = new ButtonWidget<>();
+        ShapePreviewWidget preview = new ShapePreviewWidget(shape);
+        int itemWidth = Math.max(0, (getArea().width <= 0 ? 180 : getArea().width) - ROW_CONTENT_GUTTER);
+        button.size(itemWidth, ROW_HEIGHT);
+        preview.size(itemWidth, ROW_HEIGHT);
+
+        int index = menu.count;
+        menu.addItem(button);
+
+        button.child(preview);
+        button.pos(0, index * ROW_HEIGHT);
+        button.onMouseReleased(m -> {
+            menu.setOpened(false);
+            menu.setCurrentIndex(index);
+            onSelect.selected(this);
+            return true;
+        });
+        return getThis();
+    }
+
+    @Override
+    public Result onMousePressed(int mouseButton) {
+        if (!menu.isOpen()) {
+            menu.setOpened(true);
+            menu.setEnabled(true);
+            return Result.SUCCESS;
+        }
+        menu.setOpened(false);
+        menu.setEnabled(false);
+        return Result.SUCCESS;
+    }
+
+    @Override
+    public void draw(ModularGuiContext context, WidgetThemeEntry widgetTheme) {
+        super.draw(context, widgetTheme);
+        Area area = getArea();
+        int smallerSide = Math.min(area.width, area.height);
+        IWidget selectedItem = menu.getSelectedItem();
+        if (selectedItem != null) {
+            IWidget child = selectedItem.getChildren().get(0);
+            boolean oldEnabled = selectedItem.isEnabled();
+            selectedItem.setEnabled(true);
+            child.drawBackground(context, widgetTheme);
+            child.draw(context, widgetTheme);
+            child.drawForeground(context);
+            selectedItem.setEnabled(oldEnabled);
+        }
+
+        int arrowSize = smallerSide / 2;
+        if (menu.isOpen()) {
+            arrowOpened.draw(context, area.width - arrowSize, arrowSize / 2, arrowSize, arrowSize,
+                    getWidgetTheme(context.getTheme()).getTheme());
+        } else {
+            arrowClosed.draw(context, area.width - arrowSize, arrowSize / 2, arrowSize, arrowSize,
+                    getWidgetTheme(context.getTheme()).getTheme());
+        }
+    }
+
+    @Override
+    public ShapeSelectorWidget background(IDrawable... background) {
+        menu.background(background);
+        return super.background(background);
+    }
+
+    private static Mesh3d getPreviewMesh(LittleTileShapeMode shape) {
+        Mesh3d mesh = PREVIEW_MESHES.get(shape);
+        if (mesh == null) {
+            mesh = createPreviewMesh(shape);
+            PREVIEW_MESHES.put(shape, mesh);
+        }
+        return mesh;
+    }
+
+    private static Mesh3d createPreviewMesh(LittleTileShapeMode shape) {
+        if (shape == LittleTileShapeMode.BOX) {
+            return createBoxMesh();
+        }
+
+        LittleTileCutoutInfo cutoutInfo = new LittleTileCutoutInfo();
+        cutoutInfo.type = shape;
+        cutoutInfo.size = new Vector3i(FULL_TILE);
+        cutoutInfo.pos = new Vector3i();
+        cutoutInfo.orientation = 0;
+
+        if (shape == LittleTileShapeMode.PILLAR) {
+            cutoutInfo.thickness = 5;
+            cutoutInfo.faceStart = ForgeDirection.SOUTH;
+            cutoutInfo.faceEnd = ForgeDirection.UP;
+            Mesh3d mesh = Mesh3dUtil.createMesh(cutoutInfo, new Vector3d(1, 1, 1), new Vector3d(), ZERO, ZERO, FULL_TILE,
+                    null, 0, 0);
+            mesh.setTextures(Blocks.quartz_block, 0);
+            return mesh;
+        }
+
+        Mesh3d mesh = Mesh3dUtil.createMesh(cutoutInfo, new Vector3d(1, 1, 1), new Vector3d(), ZERO, ZERO, FULL_TILE,
+            null, 0, 0);
+        mesh.setTextures(Blocks.quartz_block, 0);
+        return mesh;
+    }
+
+    private static Mesh3d createBoxMesh() {
+        List<Triangle3d> triangles = new ArrayList<>();
+
+        triangles.add(new Triangle3d(new Vector3d(0, 0, 1), new Vector3d(1, 0, 1), new Vector3d(1, 1, 1)));
+        triangles.add(new Triangle3d(new Vector3d(0, 0, 1), new Vector3d(1, 1, 1), new Vector3d(0, 1, 1)));
+        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(1, 1, 0), new Vector3d(1, 0, 0)));
+        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(0, 1, 0), new Vector3d(1, 1, 0)));
+        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(0, 0, 1), new Vector3d(0, 1, 1)));
+        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(0, 1, 1), new Vector3d(0, 1, 0)));
+        triangles.add(new Triangle3d(new Vector3d(1, 0, 0), new Vector3d(1, 1, 1), new Vector3d(1, 0, 1)));
+        triangles.add(new Triangle3d(new Vector3d(1, 0, 0), new Vector3d(1, 1, 0), new Vector3d(1, 1, 1)));
+        triangles.add(new Triangle3d(new Vector3d(0, 1, 0), new Vector3d(0, 1, 1), new Vector3d(1, 1, 1)));
+        triangles.add(new Triangle3d(new Vector3d(0, 1, 0), new Vector3d(1, 1, 1), new Vector3d(1, 1, 0)));
+        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(1, 0, 1), new Vector3d(0, 0, 1)));
+        triangles.add(new Triangle3d(new Vector3d(0, 0, 0), new Vector3d(1, 0, 0), new Vector3d(1, 0, 1)));
+
+        Mesh3d mesh = new Mesh3d(triangles);
+        mesh.setTextures(Blocks.quartz_block, 0);
+        return mesh;
+    }
+
+    private static void drawTexturedPreview(Mesh3d mesh, int x, int y, int size) {
+        if (mesh == null) {
+            return;
+        }
+
+        GL11.glPushMatrix();
+        boolean lightingWasEnabled = GL11.glIsEnabled(GL11.GL_LIGHTING);
+        boolean rescaleWasEnabled = GL11.glIsEnabled(GL12.GL_RESCALE_NORMAL);
+        float inventoryScale = size * 0.625F;
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+        RenderHelper.enableGUIStandardItemLighting();
+        GL11.glEnable(GL11.GL_LIGHTING);
+        Minecraft.getMinecraft().getTextureManager().bindTexture(TextureMap.locationBlocksTexture);
+        GL11.glTranslatef(x - size * 0.125F, y + size * 0.1875F, 0.0F);
+        GL11.glScalef(inventoryScale, inventoryScale, inventoryScale);
+        GL11.glTranslatef(1.0F, 0.5F, 1.0F);
+        GL11.glScalef(1.0F, 1.0F, -1.0F);
+        GL11.glRotatef(210.0F, 1.0F, 0.0F, 0.0F);
+        GL11.glRotatef(45.0F, 0.0F, 1.0F, 0.0F);
+        GL11.glRotatef(-90.0F, 0.0F, 1.0F, 0.0F);
+        GL11.glColor4d(1, 1, 1, 1);
+        for (Triangle3d triangle : mesh.getTriangles()) {
+            Vector3d normal = triangle.getNormal();
+            GL11.glBegin(GL11.GL_TRIANGLES);
+            GL11.glNormal3d(normal.x, normal.y, normal.z);
+            GL11.glTexCoord2d(triangle.getTex1().x, triangle.getTex1().y);
+            vertex(triangle.getP1());
+            GL11.glTexCoord2d(triangle.getTex2().x, triangle.getTex2().y);
+            vertex(triangle.getP2());
+            GL11.glTexCoord2d(triangle.getTex3().x, triangle.getTex3().y);
+            vertex(triangle.getP3());
+            GL11.glEnd();
+        }
+        GL11.glDisable(GL11.GL_BLEND);
+        if (!rescaleWasEnabled) {
+            GL11.glDisable(GL12.GL_RESCALE_NORMAL);
+        }
+        if (!lightingWasEnabled) {
+            GL11.glDisable(GL11.GL_LIGHTING);
+        } else {
+            GL11.glEnable(GL11.GL_LIGHTING);
+        }
+        GL11.glPopMatrix();
+    }
+
+    private static void vertex(Vector3d point) {
+        GL11.glVertex3d(point.x, point.y, point.z);
+    }
+
+    private static class ShapePreviewWidget extends TextWidget {
+
+        private final LittleTileShapeMode shape;
+        private final IKey label;
+
+        public ShapePreviewWidget(LittleTileShapeMode shape) {
+            super(IKey.str(shape.getName()));
+            this.shape = shape;
+            this.label = IKey.str(shape.getName());
+        }
+
+        @Override
+        public void draw(ModularGuiContext context, WidgetThemeEntry widgetTheme) {
+            Area area = getArea();
+            WidgetTheme theme = getWidgetTheme(context.getTheme()).getTheme();
+            int previewX = 3;
+            int previewY = Math.max(0, (area.height - PREVIEW_SIZE) / 2);
+            drawTexturedPreview(getPreviewMesh(shape), previewX, previewY, PREVIEW_SIZE);
+            label.draw(context, PREVIEW_SIZE + 8, 0, 0, area.height, theme);
+        }
+    }
+
+    private static class DropDownWrapper extends ScrollWidget<ShapeSelectorWidget.DropDownWrapper> {
+
+        private final List<ButtonWidget<?>> children = new ArrayList<>();
+        private boolean open;
+        private int count = 0;
+        private int currentIndex = -1;
+        private final ScrollWidget<?> scroll = new ScrollWidget<>(new VerticalScrollData());
+        private final ParentWidget<?> panel = new ParentWidget<>();
+
+        public DropDownWrapper() {
+            panel.addChild(scroll, 0);
+            scroll.pos(4, 4);
+        }
+
+        @Override
+        public void onUpdate() {
+            if (!open) {
+                setEnabled(false);
+            }
+        }
+
+        public void setOpened(boolean open) {
+            this.open = open;
+            rebuild();
+        }
+
+        public boolean isOpen() {
+            return open;
+        }
+
+        public void addItem(ButtonWidget<?> widget) {
+            children.add(widget);
+            scroll.addChild(widget, count);
+            count++;
+        }
+
+        public int getCurrentIndex() {
+            return currentIndex;
+        }
+
+        public void setCurrentIndex(int currentIndex) {
+            this.currentIndex = currentIndex;
+        }
+
+        @Override
+        public List<IWidget> getChildren() {
+            List<IWidget> ret = new ArrayList<>();
+            ret.add(panel);
+            return ret;
+        }
+
+        public IWidget getSelectedItem() {
+            if (currentIndex < 0 || currentIndex >= count) {
+                return null;
+            }
+            return children.get(currentIndex);
+        }
+
+        @Override
+        public ShapeSelectorWidget.DropDownWrapper background(IDrawable... background) {
+            panel.background(background);
+            return super.background();
+        }
+
+        @Override
+        public void onResized() {
+            super.onResized();
+            if (!isValid()) {
+                return;
+            }
+
+            int width = getParentArea().width;
+            int visibleRows = Math.min(Math.max(count, 1), VISIBLE_ROWS);
+            scroll.size(width - 8, visibleRows * ROW_HEIGHT);
+            scroll.getScrollArea().getScrollY().setScrollSize(count * ROW_HEIGHT);
+
+            panel.size(width, visibleRows * ROW_HEIGHT + 8);
+            size(width, visibleRows * ROW_HEIGHT + 8);
+            pos(0, getParentArea().height);
+
+            List<IWidget> children = getChildren();
+            for (IWidget child : children) {
+                child.setEnabled(open);
+            }
+        }
+
+        private void rebuild() {
+            WidgetTree.resize(this);
+        }
+    }
+
+    @FunctionalInterface
+    public interface ShapeSelected {
+
+        void selected(ShapeSelectorWidget menu);
+    }
+}

--- a/src/main/java/com/creativemd/littletiles/common/items/ItemBlockTiles.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemBlockTiles.java
@@ -33,6 +33,7 @@ import com.creativemd.littletiles.common.utils.LittleTilePlaceMode;
 import com.creativemd.littletiles.common.utils.LittleTilePreview;
 import com.creativemd.littletiles.common.utils.LittleToolHandler;
 import com.creativemd.littletiles.common.utils.PlacementHelper;
+import com.creativemd.littletiles.common.utils.small.LittleTileSize;
 import com.creativemd.littletiles.utils.PreviewTile;
 
 import cpw.mods.fml.common.FMLCommonHandler;

--- a/src/main/java/com/creativemd/littletiles/common/items/ItemLittleChisel.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemLittleChisel.java
@@ -57,6 +57,9 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 public class ItemLittleChisel extends Item implements ILittleTile, IGuiHolder<PlayerInventoryGuiData> {
 
+    private static final int WIDGET_WIDTH = 180;
+    private static final int WIDGET_MARGIN = 5;
+
     public ItemLittleChisel() {
         setCreativeTab(CreativeTabs.tabTools);
         hasSubtypes = true;
@@ -189,7 +192,7 @@ public class ItemLittleChisel extends Item implements ILittleTile, IGuiHolder<Pl
     private BlockDisplayWidget addBlockDisplay(PanelSyncManager syncManager, BlockStateSyncValue syncBlock,
             LittleToolHandler handler, int y) {
         BlockDisplayWidget blockDisplay = new BlockDisplayWidget(syncManager, syncBlock);
-        blockDisplay.size(150, 20).pos(5, y).marginLeft(5);
+        blockDisplay.size(WIDGET_WIDTH, 20).pos(WIDGET_MARGIN, y).marginLeft(WIDGET_MARGIN);
 
         blockDisplay.addAllBlocks(BlockValidator::isBlockValid);
 
@@ -200,10 +203,10 @@ public class ItemLittleChisel extends Item implements ILittleTile, IGuiHolder<Pl
 
     private Flow addGridSelector(IntSyncValue syncGrid, LittleToolHandler handler, int y) {
         Flow flow = new Flow(GuiAxis.X);
-        flow.pos(5, y).size(100, 20);
-        TextWidget<?> labelGrid = IKey.str("Grid:").asWidget().marginLeft(5).width(40);
+        flow.pos(WIDGET_MARGIN, y).size(WIDGET_WIDTH, 20);
+        TextWidget<?> labelGrid = IKey.str("Grid:").asWidget().marginLeft(WIDGET_MARGIN).width(40);
         DropDownMenu gridPicker = new DropDownMenu();
-        gridPicker.marginLeft(5).marginRight(5).size(40, 20);
+        gridPicker.marginLeft(WIDGET_MARGIN).marginRight(WIDGET_MARGIN).size(40, 20);
         gridPicker.background(GuiTextures.BUTTON_CLEAN);
         TextButtonWidget buttonLeft = new TextButtonWidget();
         TextButtonWidget buttonRight = new TextButtonWidget();
@@ -250,7 +253,7 @@ public class ItemLittleChisel extends Item implements ILittleTile, IGuiHolder<Pl
 
     private ShapeSelectorWidget addShapeSelector(IntSyncValue sync, LittleToolHandler handler, int y) {
         ShapeSelectorWidget shapePicker = new ShapeSelectorWidget();
-        shapePicker.pos(5, y).size(180, 20).marginLeft(10);
+        shapePicker.pos(WIDGET_MARGIN, y).size(WIDGET_WIDTH, 20).marginLeft(WIDGET_MARGIN);
         shapePicker.background(GuiTextures.BUTTON_CLEAN);
 
         for (LittleTileShapeMode mode : LittleTileShapeMode.values()) {
@@ -266,10 +269,10 @@ public class ItemLittleChisel extends Item implements ILittleTile, IGuiHolder<Pl
 
     private Flow addPlaceModeSelector(IntSyncValue sync, LittleToolHandler handler, int y) {
         Flow flow = new Flow(GuiAxis.X);
-        flow.pos(5, y).size(120, 40);
+        flow.pos(WIDGET_MARGIN, y).size(120, 40);
 
         DropDownMenu placeModePicker = new DropDownMenu();
-        placeModePicker.size(90, 30).marginLeft(10);
+        placeModePicker.size(120, 20);
         placeModePicker.background(GuiTextures.BUTTON_CLEAN);
 
         IKey placeModeInfoKey = new DynamicKey(() -> IKey.str(handler.getPlaceMode().getInfo()));
@@ -283,7 +286,7 @@ public class ItemLittleChisel extends Item implements ILittleTile, IGuiHolder<Pl
         placeModePicker.setSelectedIndex(placeMode);
 
         flow.child(placeModePicker);
-        flow.child(placeModeInfoKey.asWidget().marginLeft(10));
+        flow.child(placeModeInfoKey.asWidget().marginLeft(WIDGET_MARGIN));
 
         return flow;
     }

--- a/src/main/java/com/creativemd/littletiles/common/items/ItemLittleChisel.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemLittleChisel.java
@@ -36,6 +36,7 @@ import com.creativemd.littletiles.client.render.PreviewRenderer;
 import com.creativemd.littletiles.common.BlockValidator;
 import com.creativemd.littletiles.common.blocks.ILittleTile;
 import com.creativemd.littletiles.common.gui.BlockDisplayWidget;
+import com.creativemd.littletiles.common.gui.ShapeSelectorWidget;
 import com.creativemd.littletiles.common.gui.TextButtonWidget;
 import com.creativemd.littletiles.common.structure.LittleStructure;
 import com.creativemd.littletiles.common.utils.BlockStateSyncValue;
@@ -247,14 +248,14 @@ public class ItemLittleChisel extends Item implements ILittleTile, IGuiHolder<Pl
         return flow;
     }
 
-    private DropDownMenu addShapeSelector(IntSyncValue sync, LittleToolHandler handler, int y) {
-        DropDownMenu shapePicker = new DropDownMenu();
-        shapePicker.pos(5, y).size(150, 25).marginLeft(10);
+    private ShapeSelectorWidget addShapeSelector(IntSyncValue sync, LittleToolHandler handler, int y) {
+        ShapeSelectorWidget shapePicker = new ShapeSelectorWidget();
+        shapePicker.pos(5, y).size(180, 20).marginLeft(10);
         shapePicker.background(GuiTextures.BUTTON_CLEAN);
 
         for (LittleTileShapeMode mode : LittleTileShapeMode.values()) {
             int id = mode.ordinal();
-            shapePicker.addChoice(x -> sync.setIntValue(id), mode.getName());
+            shapePicker.addChoice(x -> sync.setIntValue(id), mode);
         }
 
         int shape = handler.getShape().ordinal();


### PR DESCRIPTION
## Summary
Implements an improved shape selector for the Chisel GUI.
- Adds a shape preview generated from the actual meshes (currently uses quartz as a texture with shading).
- Adds a scrollbar to support any number of shapes.
<img width="756" height="898" alt="image" src="https://github.com/user-attachments/assets/c37db84e-e539-4500-8955-408622a4da83" />

Also improves the block picker to make it look consistent with the shape picker:
<img width="780" height="934" alt="image" src="https://github.com/user-attachments/assets/51663428-1521-4606-ad14-e889869fbdbe" />


## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
