### PR TITLE
Rename LittleTileRenderCache to LittleTileGeometryCache

### DIFF
--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesBlockRenderHelper.java
@@ -88,7 +88,7 @@ public class LittleTilesBlockRenderHelper {
 
     private static CutoutResult renderCutout(int x, int y, int z, LittleTilesCubeObject cube, CullingContext culling,
             IBlockAccess world) {
-        if (!cube.renderCache.hasValidMesh()) {
+        if (!cube.geometryCache.hasValidMesh()) {
             return CutoutResult.FAILED;
         }
 
@@ -137,10 +137,10 @@ public class LittleTilesBlockRenderHelper {
                 continue;
             }
             if (cube.cutoutInfo != null) {
-                if (cube.renderCache.hasValidMesh() && cube.renderCache.getVisibleCutoutTriangles() == null) {
+                if (cube.geometryCache.hasValidMesh() && cube.geometryCache.getVisibleCutoutTriangles() == null) {
                     return true;
                 }
-            } else if (coverage[i] instanceof FaceClipper && cube.renderCache.getVisibleBoxTriangles() == null) {
+            } else if (coverage[i] instanceof FaceClipper && cube.geometryCache.getVisibleBoxTriangles() == null) {
                 return true;
             }
         }
@@ -247,7 +247,7 @@ public class LittleTilesBlockRenderHelper {
 
             if (cube instanceof LittleTilesCubeObject) {
                 LittleTilesCubeObject littleCube = (LittleTilesCubeObject) cube;
-                Mesh3d mesh = littleCube.renderCache == null ? null : littleCube.renderCache.getSimpleMesh();
+                Mesh3d mesh = littleCube.geometryCache == null ? null : littleCube.geometryCache.getSimpleMesh();
                 if (mesh != null) {
                     mesh = mesh.copy();
                     // Recipe meshes retain their multi-block position (for example, x = 1..2 for a tile in the

--- a/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/LittleTilesFaceCuller.java
@@ -19,7 +19,7 @@ import com.creativemd.creativecore.lib.Vector3d;
 import com.creativemd.littletiles.client.util3d.Triangle3d;
 import com.creativemd.littletiles.common.tileentity.TileEntityLittleTiles;
 import com.creativemd.littletiles.common.utils.LittleTile;
-import com.creativemd.littletiles.common.utils.LittleTileRenderCache;
+import com.creativemd.littletiles.common.utils.LittleTileGeometryCache;
 import com.creativemd.littletiles.common.utils.LittleTilesCubeObject;
 
 import cpw.mods.fml.relauncher.Side;
@@ -246,7 +246,7 @@ public final class LittleTilesFaceCuller {
                 // copies, since these get moved and the mesh is the one cached on the neighbouring tile
                 List<Triangle3d> triangles;
                 if (neighbour.cutoutInfo != null) {
-                    triangles = neighbour.renderCache.getSimpleMesh().copy().getTriangles();
+                    triangles = neighbour.geometryCache.getSimpleMesh().copy().getTriangles();
                 } else {
                     triangles = boxFaceTriangles(neighbour, facingUs);
                 }
@@ -273,14 +273,14 @@ public final class LittleTilesFaceCuller {
      * ones in the same tile entity and the ones in the six neighbours.
      */
     public static List<Triangle3d> visibleCutoutTriangles(CullingContext culling, LittleTilesCubeObject cube) {
-        LittleTileRenderCache cache = cube.renderCache;
+        LittleTileGeometryCache cache = cube.geometryCache;
         List<Triangle3d> cached = cache.getVisibleCutoutTriangles();
         if (cached != null) {
             return cached;
         }
         List<Triangle3d> occludingTriangles = getOccludingTriangles(culling, cube, false);
         List<Triangle3d> visible = new ArrayList<>();
-        for (Triangle3d triangle : cube.renderCache.getSimpleMesh().getTriangles()) {
+        for (Triangle3d triangle : cube.geometryCache.getSimpleMesh().getTriangles()) {
             visible.addAll(cutTriangle(triangle, occludingTriangles));
         }
         cache.setVisibleCutoutTriangles(visible);
@@ -293,7 +293,7 @@ public final class LittleTilesFaceCuller {
      */
     public static List<Triangle3d> visibleBoxTriangles(CullingContext culling, LittleTilesCubeObject cube,
             FaceClipper clipper) {
-        LittleTileRenderCache cache = cube.renderCache;
+        LittleTileGeometryCache cache = cube.geometryCache;
         List<Triangle3d> cached = cache.getVisibleBoxTriangles();
         if (cached != null) {
             // the clipper is new for every render, so the sides that are drawn as triangles have to be hidden again
@@ -324,7 +324,7 @@ public final class LittleTilesFaceCuller {
 
     /** Replays onto a fresh clipper which sides were replaced by triangles when the cut result was computed. */
     private static void coverReplacedBoxSides(FaceClipper clipper, LittleTilesCubeObject cube) {
-        int replacedSides = cube.renderCache.getReplacedBoxSides();
+        int replacedSides = cube.geometryCache.getReplacedBoxSides();
         for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
             if ((replacedSides & 1 << side.ordinal()) != 0) {
                 coverSide(clipper, cube, cube, side);
@@ -357,7 +357,7 @@ public final class LittleTilesFaceCuller {
                 continue;
             }
             if (occluder.cutoutInfo != null) {
-                occludingTriangles.addAll(occluder.renderCache.getSimpleMesh().getTriangles());
+                occludingTriangles.addAll(occluder.geometryCache.getSimpleMesh().getTriangles());
             } else if (!meshOccludersOnly) {
                 for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
                     if (isFlush(cube, occluder, side)) {

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTile.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTile.java
@@ -122,7 +122,9 @@ public abstract class LittleTile {
 
     private LittleTileCutoutInfo cutoutInfo = null;
 
-    private final LittleTileGeometryCache geometryCache = new LittleTileGeometryCache(() -> boundingBox, () -> cutoutInfo);
+    private final LittleTileGeometryCache geometryCache = new LittleTileGeometryCache(
+            () -> boundingBox,
+            () -> cutoutInfo);
 
     public AxisAlignedBB getSelectedBox() {
         if (boundingBox != null) {

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTile.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTile.java
@@ -122,7 +122,7 @@ public abstract class LittleTile {
 
     private LittleTileCutoutInfo cutoutInfo = null;
 
-    private final LittleTileRenderCache renderCache = new LittleTileRenderCache(() -> boundingBox, () -> cutoutInfo);
+    private final LittleTileGeometryCache geometryCache = new LittleTileGeometryCache(() -> boundingBox, () -> cutoutInfo);
 
     public AxisAlignedBB getSelectedBox() {
         if (boundingBox != null) {
@@ -473,23 +473,23 @@ public abstract class LittleTile {
             return null;
         }
         if (FMLCommonHandler.instance().getEffectiveSide().isClient()) {
-            return renderCache.getSimpleMesh();
+            return geometryCache.getSimpleMesh();
         }
         return Mesh3dUtil.meshFromTile(boundingBox, cutoutInfo);
     }
 
     private void invalidateClientMeshCache() {
-        renderCache.invalidateMesh();
+        geometryCache.invalidateMesh();
     }
 
     /** Drops what culling produced for this tile, without dropping the mesh it was cut from. */
     public void invalidateClientCutCache() {
-        renderCache.invalidateCuts();
+        geometryCache.invalidateCuts();
     }
 
     @SideOnly(Side.CLIENT)
-    public LittleTileRenderCache getRenderCache() {
-        return renderCache;
+    public LittleTileGeometryCache getGeometryCache() {
+        return geometryCache;
     }
 
     public boolean overlapsTile(LittleTile other) {

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTileBlock.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTileBlock.java
@@ -76,7 +76,7 @@ public class LittleTileBlock extends LittleTile {
             cube.block = block;
             cube.meta = meta;
             cube.cutoutInfo = this.getCutoutInfo();
-            cube.renderCache = getRenderCache();
+            cube.geometryCache = getGeometryCache();
             cubes.add(cube);
         }
         return cubes;

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTileGeometryCache.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTileGeometryCache.java
@@ -13,7 +13,7 @@ import com.creativemd.littletiles.common.utils.small.LittleTileBox;
 /**
  * Client render geometry retained for a little tile.
  */
-public class LittleTileRenderCache {
+public class LittleTileGeometryCache {
 
     private final Supplier<LittleTileBox> boxGetter;
     private final Supplier<LittleTileCutoutInfo> cutoutGetter;
@@ -25,7 +25,7 @@ public class LittleTileRenderCache {
     /** Bit set of {@link ForgeDirection#ordinal()}: the sides drawn as triangles instead of as rectangles. */
     private int replacedBoxSides;
 
-    public LittleTileRenderCache(Supplier<LittleTileBox> boxGetter, Supplier<LittleTileCutoutInfo> cutoutGetter) {
+    public LittleTileGeometryCache(Supplier<LittleTileBox> boxGetter, Supplier<LittleTileCutoutInfo> cutoutGetter) {
         this.boxGetter = boxGetter;
         this.cutoutGetter = cutoutGetter;
     }

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTilePreview.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTilePreview.java
@@ -53,7 +53,7 @@ public final class LittleTilePreview {
             cube.block = Blocks.stone;
         }
         cube.cutoutInfo = LittleTileCutoutInfo.loadFromNBT(nbt);
-        cube.renderCache = new LittleTileRenderCache(() -> renderBox, () -> cube.cutoutInfo);
+        cube.geometryCache = new LittleTileGeometryCache(() -> renderBox, () -> cube.cutoutInfo);
         if (nbt.hasKey("color")) cube.color = nbt.getInteger("color");
         return cube;
     }

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleTilesCubeObject.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleTilesCubeObject.java
@@ -9,7 +9,7 @@ import com.creativemd.creativecore.common.utils.RotationUtils.Axis;
 public class LittleTilesCubeObject extends CubeObject {
 
     public LittleTileCutoutInfo cutoutInfo;
-    public LittleTileRenderCache renderCache;
+    public LittleTileGeometryCache geometryCache;
 
     /**
      * Bounds on the 1/16 grid. Kept alongside the double bounds so face occlusion can be computed with exact integer


### PR DESCRIPTION
## Summary
This is a trivial rename using the IDE. It only caches the geometry, and will cause confusion if I add an actual render cache that caches OpenGL state in a VBO.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
