### PR TITLE
Fix compile warning and LittleHammer on single tile

### DIFF
--- a/src/main/java/com/creativemd/littletiles/common/items/ItemLittleChisel.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemLittleChisel.java
@@ -23,6 +23,7 @@ import com.cleanroommc.modularui.drawable.GuiTextures;
 import com.cleanroommc.modularui.drawable.text.DynamicKey;
 import com.cleanroommc.modularui.factory.PlayerInventoryGuiData;
 import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.screen.ModularScreen;
 import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.value.sync.IntSyncValue;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
@@ -153,6 +154,12 @@ public class ItemLittleChisel extends Item implements ILittleTile, IGuiHolder<Pl
         LittleTilePreview preview = new LittleTilePreview(size, nbt);
         ret.add(preview);
         return ret;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public ModularScreen createScreen(PlayerInventoryGuiData data, ModularPanel mainPanel) {
+        return new ModularScreen(LittleTiles.modid, mainPanel);
     }
 
     private void selectBlock(PlayerInventoryGuiData data, Block block, int meta) {

--- a/src/main/java/com/creativemd/littletiles/common/packet/LittleBlockPacket.java
+++ b/src/main/java/com/creativemd/littletiles/common/packet/LittleBlockPacket.java
@@ -218,7 +218,7 @@ public class LittleBlockPacket extends CreativeCorePacket {
                             }
 
                             if (LittleTiles.maxNewTiles >= newTiles.size() - 1) {
-                                te.removeTile(oldTile);
+                                te.removeTile(oldTile, false);
                                 te.addTiles(newTiles);
                                 te.update();
                             } else {


### PR DESCRIPTION
## Summary
This PR fixes a compile warning with MUI2 and makes the little hammer work on a single tile. If the hammer removes the last tile it removes the tile - need to pass the flag to keep it.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
