### PR TITLE
Add flip support for meshes

### DIFF
--- a/src/main/java/com/creativemd/littletiles/client/util3d/OrientationMapper.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/OrientationMapper.java
@@ -9,7 +9,8 @@ import org.joml.Matrix3f;
 
 public class OrientationMapper {
 
-    private static final int NUM_ORIENTATIONS = 24;
+    /** The 24 proper rotations plus their 24 mirrored counterparts, covering every flipped/rotated cube orientation. */
+    private static final int NUM_ORIENTATIONS = 48;
     private static final List<Matrix3f> ORIENTATIONS = new ArrayList<>();
     private static final Map<String, Integer> LOOKUP = new HashMap<>();
 
@@ -37,8 +38,23 @@ public class OrientationMapper {
             }
         }
 
+        // Mirror every proper rotation found above to also cover the 24 improper (reflected) orientations, giving the
+        // full 48-element cube symmetry group needed to represent flipped meshes.
+        Matrix3f mirror = new Matrix3f(-1, 0, 0, 0, 1, 0, 0, 0, 1);
+        int properCount = ORIENTATIONS.size();
+        for (int i = 0; i < properCount; i++) {
+            Matrix3f mirrored = new Matrix3f(mirror).mul(ORIENTATIONS.get(i));
+            snapToCubeOrientation(mirrored);
+
+            String key = toKey(mirrored);
+            if (!LOOKUP.containsKey(key)) {
+                ORIENTATIONS.add(mirrored);
+                LOOKUP.put(key, id++);
+            }
+        }
+
         if (ORIENTATIONS.size() != NUM_ORIENTATIONS)
-            throw new RuntimeException("Expected 24 orientations, got " + ORIENTATIONS.size());
+            throw new RuntimeException("Expected " + NUM_ORIENTATIONS + " orientations, got " + ORIENTATIONS.size());
     }
 
     /**

--- a/src/main/java/com/creativemd/littletiles/client/util3d/Triangle3d.java
+++ b/src/main/java/com/creativemd/littletiles/client/util3d/Triangle3d.java
@@ -159,6 +159,11 @@ public class Triangle3d {
         p1 = rotateVector(p1, matrix);
         p2 = rotateVector(p2, matrix);
         p3 = rotateVector(p3, matrix);
+        // Mirrored orientations (used for flipped meshes) invert the winding order, so it has to be restored here to
+        // keep the normal pointing outwards.
+        if (matrix.determinant() < 0) {
+            flipWindingOrder();
+        }
     }
 
     /**

--- a/src/main/java/com/creativemd/littletiles/common/items/ItemBlockTiles.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemBlockTiles.java
@@ -259,7 +259,12 @@ public class ItemBlockTiles extends ItemBlock implements ILittleTile, ITilesRend
 
     @Override
     public void flipLittlePreview(ItemStack stack, ForgeDirection direction) {
-        // No need to flip one single tile!
+        // A single tile's box never needs flipping, but a chiseled mesh shape still does.
+        if (!stack.hasTagCompound()) return;
+        if (stack.stackTagCompound.hasKey("cutoutOrientation")) {
+            LittleTileSize oldSize = LittleTilePreview.getSizeFromNBT(stack.stackTagCompound);
+            new LittleToolHandler(stack).handleFlip(direction, oldSize);
+        }
     }
 
 }

--- a/src/main/java/com/creativemd/littletiles/common/items/ItemLittleChisel.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemLittleChisel.java
@@ -95,7 +95,8 @@ public class ItemLittleChisel extends Item implements ILittleTile, IGuiHolder<Pl
 
     @Override
     public void flipLittlePreview(ItemStack stack, ForgeDirection direction) {
-
+        LittleToolHandler handler = new LittleToolHandler(stack);
+        handler.handleFlip(direction, null);
     }
 
     @Override

--- a/src/main/java/com/creativemd/littletiles/common/items/ItemRecipe.java
+++ b/src/main/java/com/creativemd/littletiles/common/items/ItemRecipe.java
@@ -136,7 +136,11 @@ public class ItemRecipe extends Item implements ITilesRenderer, IGuiCreator {
         int tiles = stack.stackTagCompound.getInteger("tiles");
         for (int i = 0; i < tiles; i++) {
             NBTTagCompound nbt = stack.stackTagCompound.getCompoundTag("tile" + i);
+            LittleTileSize oldSize = LittleTilePreview.getSizeFromNBT(nbt);
             LittleTilePreview.flipPreview(nbt, direction);
+            if (nbt.hasKey("cutoutOrientation")) {
+                new LittleToolHandler(nbt).handleFlip(direction, oldSize);
+            }
             stack.stackTagCompound.setTag("tile" + i, nbt);
         }
     }

--- a/src/main/java/com/creativemd/littletiles/common/utils/LittleToolHandler.java
+++ b/src/main/java/com/creativemd/littletiles/common/utils/LittleToolHandler.java
@@ -171,6 +171,23 @@ public class LittleToolHandler {
                 toVector3f(RotationUtils.applyVectorRotation(Vec3.createVectorHelper(0, 0, 1), rotation)));
     }
 
+    /** Mirror matrix for flipping a cutout on the axis of the given direction, in the same space tile boxes use. */
+    private static Matrix3f getFlipMatrix(ForgeDirection direction) {
+        switch (direction) {
+            case EAST:
+            case WEST:
+                return new Matrix3f(-1, 0, 0, 0, 1, 0, 0, 0, 1);
+            case UP:
+            case DOWN:
+                return new Matrix3f(1, 0, 0, 0, -1, 0, 0, 0, 1);
+            case SOUTH:
+            case NORTH:
+                return new Matrix3f(1, 0, 0, 0, 1, 0, 0, 0, -1);
+            default:
+                return new Matrix3f();
+        }
+    }
+
     /**
      * Handles rotation for a cutout. Only 90 degrees and only one axis.
      *
@@ -179,20 +196,33 @@ public class LittleToolHandler {
      */
     public void handleRotation(ForgeDirection direction, LittleTileSize oldSize) {
         // Get rotation the user requested, in the same convention the tile boxes are rotated with
-        Matrix3f rotation = getRotationMatrix(direction);
+        applyCutoutTransform(getRotationMatrix(direction), oldSize);
+    }
 
-        // Get saved rotation
+    /**
+     * Handles flipping (mirroring) a cutout. Shares the exact same cutout pos/size/face bookkeeping rotation uses,
+     * since a mirror is just another linear transform of the same cutout space; only the matrix differs.
+     *
+     * @param oldSize size of the tile before it got flipped, null if unknown. Flipping never changes a tile's size, so
+     *                callers may always pass the tile's current size.
+     */
+    public void handleFlip(ForgeDirection direction, LittleTileSize oldSize) {
+        applyCutoutTransform(getFlipMatrix(direction), oldSize);
+    }
+
+    private void applyCutoutTransform(Matrix3f transform, LittleTileSize oldSize) {
+        // Get saved orientation
         int orientation = getOrientation();
         Matrix3f matrix = OrientationMapper.fromId(orientation);
 
-        // Apply new rotation and save
-        matrix = new Matrix3f(rotation).mul(matrix);
+        // Apply new transform and save
+        matrix = new Matrix3f(transform).mul(matrix);
         orientation = OrientationMapper.toId(matrix);
         setOrientation(orientation);
 
         NBTTagCompound nbt = getTag(true);
 
-        // Handle rotation for block-picked tiles. We need to rotate the cutout pos/size as well...
+        // Handle transform for block-picked tiles. We need to transform the cutout pos/size as well...
         if (nbt.hasKey("cutoutPosX") && oldSize != null) {
             int cutoutSizeX = nbt.getInteger("cutoutSizeX");
             int cutoutSizeY = nbt.getInteger("cutoutSizeY");
@@ -202,7 +232,7 @@ public class LittleToolHandler {
             int cutoutPosY = nbt.getInteger("cutoutPosY");
             int cutoutPosZ = nbt.getInteger("cutoutPosZ");
 
-            // Treat cutout pos + size as cuboid to rotate it properly
+            // Treat cutout pos + size as cuboid to transform it properly
             int minX = cutoutPosX;
             int minY = cutoutPosY;
             int minZ = cutoutPosZ;
@@ -210,9 +240,9 @@ public class LittleToolHandler {
             int maxY = minY + cutoutSizeY - oldSize.sizeY;
             int maxZ = minZ + cutoutSizeZ - oldSize.sizeZ;
 
-            // Rotate cuboid
-            Vector3f v1 = rotation.transform(new Vector3f(minX, minY, minZ));
-            Vector3f v2 = rotation.transform(new Vector3f(maxX, maxY, maxZ));
+            // Transform cuboid
+            Vector3f v1 = transform.transform(new Vector3f(minX, minY, minZ));
+            Vector3f v2 = transform.transform(new Vector3f(maxX, maxY, maxZ));
 
             // Save new start pos
             cutoutPosX = Math.round(Math.min(v1.x, v2.x));
@@ -222,8 +252,8 @@ public class LittleToolHandler {
             nbt.setInteger("cutoutPosY", cutoutPosY);
             nbt.setInteger("cutoutPosZ", cutoutPosZ);
 
-            // Rotate size as well. The rotation only permutes the axes, so the size just follows along.
-            Vector3f size = rotation.transform(new Vector3f(cutoutSizeX, cutoutSizeY, cutoutSizeZ));
+            // Transform size as well. Rotation/flip only permutes or mirrors the axes, so the size just follows along.
+            Vector3f size = transform.transform(new Vector3f(cutoutSizeX, cutoutSizeY, cutoutSizeZ));
             nbt.setInteger("cutoutSizeX", Math.abs(Math.round(size.x)));
             nbt.setInteger("cutoutSizeY", Math.abs(Math.round(size.y)));
             nbt.setInteger("cutoutSizeZ", Math.abs(Math.round(size.z)));
@@ -233,7 +263,7 @@ public class LittleToolHandler {
             boolean negZ = nbt.getBoolean("cutoutNegZ");
 
             Vector3f negVec = new Vector3f(negX ? -1 : 1, negY ? -1 : 1, negZ ? -1 : 1);
-            negVec = rotation.transform(negVec);
+            negVec = transform.transform(negVec);
             negX = negVec.x < 0;
             negY = negVec.y < 0;
             negZ = negVec.z < 0;
@@ -247,8 +277,8 @@ public class LittleToolHandler {
             Vector3d faceStart = Plane3d.planes[faceStartI].getNormal();
             Vector3d faceEnd = Plane3d.planes[faceEndI].getNormal();
 
-            faceStart = new Vector3d(rotation.transform(faceStart.toVector3f()));
-            faceEnd = new Vector3d(rotation.transform(faceEnd.toVector3f()));
+            faceStart = new Vector3d(transform.transform(faceStart.toVector3f()));
+            faceEnd = new Vector3d(transform.transform(faceEnd.toVector3f()));
 
             faceStartI = getDirectionForNormal(faceStart).ordinal();
             faceEndI = getDirectionForNormal(faceEnd).ordinal();


### PR DESCRIPTION
## Summary
Adds support for meshes (and placement plans/recipes) to support flipping without breaking.
Implemented as 24 new orientation matrices that are mirrors of the existing 24 possible orientations, which means we don't need any special handling for flipped tiles.


## Checklist
- [X] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
